### PR TITLE
Allow GLTF Exporting Multi-Root SKLBs

### DIFF
--- a/VFXEditor/Utils/Gltf/GltfSkeleton.cs
+++ b/VFXEditor/Utils/Gltf/GltfSkeleton.cs
@@ -119,9 +119,9 @@ namespace VfxEditor.Utils.Gltf {
                 }
             }
 
-            scene.AddSkinnedMesh( dummyMesh, Matrix4x4.Identity, [.. bones] );
             var armature = new NodeBuilder( "Armature" );
             roots.ForEach( armature.AddNode );
+            scene.AddSkinnedMesh( dummyMesh, Matrix4x4.Identity, [.. bones] );
             scene.AddNode( armature );
 
             var model = scene.ToGltf2();


### PR DESCRIPTION
from discord issue https://discord.com/channels/1081353100012568726/1232423440548364499/1232423440548364499 vfxedit currently busts out due to SharpGLTF evaluation when trying to export a sklb's [bones] list that contains more than 1 root-node - a video example of this is in the thread and a candidate SKLB to test this behavior on is `skl_c0201t6085`

to circumvent sharpgltf's failing `IsValidArmature` evaluation on the multi-root set of bones, this fix moves the `AddSkinnedMesh()` call to occur after any of the root nodes have been parented to the Armature node. this lets us create a gltf export for multi-root cases with no disruption in output for single-root skeletons

final output can still be a bit janked up for other reasons (misc bone rotation/scaling problems) but the output gltf reimports mostly fine over the original.