### PR TITLE
Don't show a warning when effector only is assigned

### DIFF
--- a/VFXEditor/Formats/AvfxFormat/Timeline/Items/AvfxTimelineItem.cs
+++ b/VFXEditor/Formats/AvfxFormat/Timeline/Items/AvfxTimelineItem.cs
@@ -89,6 +89,11 @@ namespace VfxEditor.AvfxFormat {
                 return $"Clip {ClipIdx.Value}";
             }
 
+            if( EffectorIdx.IsAssigned() && EffectorSelect.Selected != null )
+            {
+                return EffectorSelect.GetText();
+            }
+
             return "[NONE]";
         }
 

--- a/VFXEditor/Formats/AvfxFormat/Timeline/Items/AvfxTimelineItem.cs
+++ b/VFXEditor/Formats/AvfxFormat/Timeline/Items/AvfxTimelineItem.cs
@@ -96,6 +96,6 @@ namespace VfxEditor.AvfxFormat {
 
         public AvfxEmitter Emitter => EmitterSelect.Selected;
 
-        public bool HasValue => EmitterIdx.Value >= 0 || ( ClipIdx.IsAssigned() && ClipIdx.Value >= 0 );
+        public bool HasValue => EmitterIdx.Value >= 0 || ( ClipIdx.IsAssigned() && ClipIdx.Value >= 0 ) || ( EffectorIdx.IsAssigned() && EffectorSelect.Selected != null );
     }
 }


### PR DESCRIPTION
See vfx/monster/m0884/eff/m0884show_sp04_c2p1.avfx for instance
One item contains an effector only and shouldn't throw a warning
Also added its text in for good measure instead of [NONE]