### PR TITLE
Show warning when scheduler is missing a value

### DIFF
--- a/VFXEditor/Formats/AvfxFormat/AvfxDocument.cs
+++ b/VFXEditor/Formats/AvfxFormat/AvfxDocument.cs
@@ -109,9 +109,7 @@ namespace VfxEditor.AvfxFormat {
         }
 
         protected override string GetWarningText() {
-            var invalidTimeline = File.TimelineView.Group.Items.Where( timeline => timeline.Items.Any( item => !item.HasValue ) ).FirstOrDefault();
-            if( invalidTimeline == null ) return "";
-            return $"Timeline [{invalidTimeline.GetText()}] is Missing a Value";
+            return AvfxWarning.GetWarningText(File);
         }
 
         protected override void DisplayFileControls() {

--- a/VFXEditor/Formats/AvfxFormat/AvfxWarning.cs
+++ b/VFXEditor/Formats/AvfxFormat/AvfxWarning.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using System.Collections.Generic;
+
+namespace VfxEditor.AvfxFormat {
+    public static class AvfxWarning {
+
+        public static string GetWarningText( AvfxFile File ) {
+            string text = "";
+            var list = GetWarningList( File );
+            foreach( var item in list )
+            {
+                if(item != "") text += item + "\n";
+            }
+            return text;
+        }
+
+        static List<string> GetWarningList( AvfxFile File )
+        {
+            var list = new List<string>();
+            list.Add( GetWarningTextScheduler( File ) );
+            list.Add( GetWarningTextTimeline( File ) );
+            return list;
+        }
+
+        static string GetWarningTextScheduler( AvfxFile File )
+        {
+            var invalidScheduler = File.ScheduleView.Group.Items.Where( scheduler => scheduler.Items.Any( item => !item.HasValue ) ).FirstOrDefault();
+            if( invalidScheduler != null ) return $"Scheduler [{invalidScheduler.GetText()}] is Missing a Value";
+            return "";
+        }
+
+        static string GetWarningTextTimeline( AvfxFile File )
+        {
+            string text = "";
+            foreach(var timeline in File.TimelineView.Group.Items )
+            {
+                if( timeline.Items.Any( item => !item.HasValue ) )
+                {
+                    if(text != "") { text += "\n"; }
+                    text += $"Timeline [{timeline.GetText()}] is Missing a Value";
+                }
+            }
+            return text;
+        }
+    }
+}

--- a/VFXEditor/Formats/AvfxFormat/Scheduler/AvfxSchedulerItem.cs
+++ b/VFXEditor/Formats/AvfxFormat/Scheduler/AvfxSchedulerItem.cs
@@ -48,5 +48,7 @@ namespace VfxEditor.AvfxFormat {
             ImGui.SetNextItemWidth( 100 );
             StartTime.Draw();
         }
+
+        public bool HasValue => TimelineIdx.Value >= 0;
     }
 }


### PR DESCRIPTION
![ffxiv_dx11_zZlqOEiz8h](https://github.com/user-attachments/assets/94e129d3-95e4-4eb8-adc9-71e619691df2)
Expand on the warning system to warn the user that those are missing.
Full on game crash if they decide to pop the VFX in that state.