### PR TITLE
Add support for the theming flag on ULDTexture

### DIFF
--- a/VFXEditor/Formats/UldFormat/Texture/UldTexture.cs
+++ b/VFXEditor/Formats/UldFormat/Texture/UldTexture.cs
@@ -4,10 +4,16 @@ using VfxEditor.Parsing;
 using VfxEditor.Parsing.String;
 
 namespace VfxEditor.UldFormat.Texture {
+    internal enum ThemeFlags {
+        Light = 1,
+        Classic_FF = 2,
+        Clear_Blue = 4,
+    }
+
     public class UldTexture : UldWorkspaceItem {
         public readonly ParsedPaddedString Path = new( "Path", 44, 0x00 );
         public readonly ParsedUInt IconId = new( "Icon Id" );
-        private readonly ParsedUInt Unk1 = new( "Unknown 1" );
+        private readonly ParsedFlag<ThemeFlags> ThemeFlags = new( name: "Theme Flags", showIntField: true );
 
         private bool ShowHd = false;
 
@@ -17,15 +23,15 @@ namespace VfxEditor.UldFormat.Texture {
             Id.Read( reader );
             Path.Read( reader );
             IconId.Read( reader );
-            if( minorVersion == '1' ) Unk1.Read( reader );
-            else Unk1.Value = 0;
+            if( minorVersion == '1' ) ThemeFlags.Read( reader );
+            else ThemeFlags.Value = 0;
         }
 
         public void Write( BinaryWriter writer, char minorVersion ) {
             Id.Write( writer );
             Path.Write( writer );
             IconId.Write( writer );
-            if( minorVersion == '1' ) Unk1.Write( writer );
+            if( minorVersion == '1' ) ThemeFlags.Write( writer );
         }
 
         public override void Draw() {
@@ -47,7 +53,7 @@ namespace VfxEditor.UldFormat.Texture {
                 Plugin.TextureManager.GetTexture( IconPath )?.Draw();
             }
 
-            Unk1.Draw();
+            ThemeFlags.Draw();
         }
 
         public override string GetDefaultText() => $"Texture {GetIdx()}";

--- a/VFXEditor/Parsing/Flag/ParsedFlag.cs
+++ b/VFXEditor/Parsing/Flag/ParsedFlag.cs
@@ -6,6 +6,7 @@ using System.IO;
 namespace VfxEditor.Parsing {
     public class ParsedFlag<T> : ParsedSimpleBase<T> where T : Enum {
         private readonly int Size;
+        private readonly bool ShowIntField;
 
         public int IntValue => ( int )( object )Value;
 
@@ -13,8 +14,9 @@ namespace VfxEditor.Parsing {
             Size = size;
         }
 
-        public ParsedFlag( string name, int size = 4 ) : base( name ) {
+        public ParsedFlag( string name, int size = 4, bool showIntField = false ) : base( name ) {
             Size = size;
+            ShowIntField = showIntField;
         }
 
         public override void Read( BinaryReader reader ) => Read( reader, 0 );
@@ -37,6 +39,13 @@ namespace VfxEditor.Parsing {
         }
 
         protected override void DrawBody() {
+            if ( ShowIntField ) {
+                var value = IntValue;
+                if( InTable ? ImGui.InputInt( Name, ref value, 0, 0 ) : ImGui.InputInt( Name, ref value ) ) {
+                    Update( (T)(object)value );
+                }
+            }
+
             var options = ( T[] )Enum.GetValues( typeof( T ) );
             foreach( var option in options ) {
                 var intOption = ( int )( object )option;


### PR DESCRIPTION
The Unk1 field in the ULDTexture controls whether or not the UldManager tries to map that texture to a themed variant using these bits as flags.

I added a way to optionally display/directly edit the integer value of a ParsedFlag since I'm not confident those are the _only_ flags present in that field