### PR TITLE
Add an overwrite button when a local file is loaded

### DIFF
--- a/VFXEditor/FileManager/FileManagerDocument.cs
+++ b/VFXEditor/FileManager/FileManagerDocument.cs
@@ -411,18 +411,15 @@ namespace VfxEditor.FileManager {
             }
             using( var style = ImRaii.PushStyle( ImGuiStyleVar.FramePadding, ImGui.GetStyle().FramePadding + new Vector2( 0, 1 ) ) )
             using( var font = ImRaii.PushFont( UiBuilder.IconFont ) )
-            {
-                if( ImGui.Button( FontAwesomeIcon.Download.ToIconString() ) ) ExportRawDialog();
-            }
+            if( ImGui.Button( FontAwesomeIcon.Download.ToIconString() ) ) ExportRawDialog();
             UiUtils.Tooltip( "Export as a raw file" );
 
             if( Source.Type == SelectResultType.Local )
             {
+                ImGui.SameLine();
+                using( var style = ImRaii.PushStyle( ImGuiStyleVar.FramePadding, ImGui.GetStyle().FramePadding + new Vector2( 0, 1 ) ) )
                 using( var font = ImRaii.PushFont( UiBuilder.IconFont ) )
-                {
-                    ImGui.SameLine();
-                    if( ImGui.Button( FontAwesomeIcon.Upload.ToIconString() ) ) ExportRawSilent();
-                }
+                if( ImGui.Button( FontAwesomeIcon.Upload.ToIconString() ) ) ExportRawSilent();
                 UiUtils.Tooltip( "Overwrite selected file path" );
             }
 

--- a/VFXEditor/FileManager/FileManagerDocument.cs
+++ b/VFXEditor/FileManager/FileManagerDocument.cs
@@ -140,7 +140,9 @@ namespace VfxEditor.FileManager {
             System.IO.File.WriteAllBytes( path, File.ToBytes() );
         }
 
-        protected void ExportRaw() => UiUtils.WriteBytesDialog( $".{Extension}", File.ToBytes(), Extension, "ExportedFile" );
+        protected void ExportRawDialog() => UiUtils.WriteBytesDialog( $".{Extension}", File.ToBytes(), Extension, "ExportedFile" );
+
+        protected void ExportRawSilent() => UiUtils.WriteBytesSilent( $".{Extension}", File.ToBytes(), Source.Path );
 
         public void Update() {
             if( ( DateTime.Now - LastUpdate ).TotalSeconds <= 0.2 ) return;
@@ -408,10 +410,21 @@ namespace VfxEditor.FileManager {
                 ImGui.SameLine();
             }
             using( var style = ImRaii.PushStyle( ImGuiStyleVar.FramePadding, ImGui.GetStyle().FramePadding + new Vector2( 0, 1 ) ) )
-            using( var font = ImRaii.PushFont( UiBuilder.IconFont ) ) {
-                if( ImGui.Button( FontAwesomeIcon.Download.ToIconString() ) ) ExportRaw();
+            using( var font = ImRaii.PushFont( UiBuilder.IconFont ) )
+            {
+                if( ImGui.Button( FontAwesomeIcon.Download.ToIconString() ) ) ExportRawDialog();
             }
             UiUtils.Tooltip( "Export as a raw file" );
+
+            if( Source.Type == SelectResultType.Local )
+            {
+                using( var font = ImRaii.PushFont( UiBuilder.IconFont ) )
+                {
+                    ImGui.SameLine();
+                    if( ImGui.Button( FontAwesomeIcon.Upload.ToIconString() ) ) ExportRawSilent();
+                }
+                UiUtils.Tooltip( "Overwrite selected file path" );
+            }
 
             ImGui.SameLine();
             UiUtils.ShowVerifiedStatus( Verified );

--- a/VFXEditor/FileManager/FileManagerDocument.cs
+++ b/VFXEditor/FileManager/FileManagerDocument.cs
@@ -419,7 +419,11 @@ namespace VfxEditor.FileManager {
                 ImGui.SameLine();
                 using( var style = ImRaii.PushStyle( ImGuiStyleVar.FramePadding, ImGui.GetStyle().FramePadding + new Vector2( 0, 1 ) ) )
                 using( var font = ImRaii.PushFont( UiBuilder.IconFont ) )
-                if( ImGui.Button( FontAwesomeIcon.Upload.ToIconString() ) ) ExportRawSilent();
+                    if( ImGui.Button( FontAwesomeIcon.Upload.ToIconString() ) )
+                    {
+                        ExportRawSilent();
+                        Dalamud.OkNotification( "Exported to " + Source.Path );
+                    }
                 UiUtils.Tooltip( "Overwrite selected file path" );
             }
 

--- a/VFXEditor/Utils/UiUtils.cs
+++ b/VFXEditor/Utils/UiUtils.cs
@@ -193,10 +193,16 @@ namespace VfxEditor.Utils {
             }
         }
 
-        public static void WriteBytesDialog( string filter, byte[] data, string ext, string fileName ) {
+        public static void WriteBytesDialog( string filter, byte[] data, string ext, string fileName )
+        {
             FileBrowserManager.SaveFileDialog( "Select a Save Location", filter, fileName, ext, ( bool ok, string res ) => {
                 if( ok ) File.WriteAllBytes( res, data );
             } );
+        }
+
+        public static void WriteBytesSilent( string filter, byte[] data, string filePath )
+        {
+            File.WriteAllBytes( filePath, data );
         }
 
         public static void OpenUrl( string url ) => Process.Start( new ProcessStartInfo {


### PR DESCRIPTION
![ffxiv_dx11_LDLimDLyZc](https://github.com/user-attachments/assets/17521b8c-006b-45c3-92e1-e739deb14b22)
- Use case; I've loaded a local file and want to save it where I loaded it from without needed to go find it again with raw export.
- Annex use case; I've loaded a file from Penumbra select and I want to save that file directly where it came from.

Button isn't present if the loaded file isn't a local file.