### PR TITLE
Add button to refresh locally loaded file

### DIFF
--- a/VFXEditor/FileManager/FileManagerBase.cs
+++ b/VFXEditor/FileManager/FileManagerBase.cs
@@ -1,4 +1,5 @@
 using Dalamud.Interface.Windowing;
+using SharpDX.Win32;
 using VfxEditor.Data.Copy;
 using VfxEditor.FileManager.Interfaces;
 using VfxEditor.Select;
@@ -37,6 +38,8 @@ namespace VfxEditor.FileManager {
         public ManagerConfiguration GetConfig() => Configuration;
 
         public void ShowSource() => SourceSelect?.Show();
+
+        public void RefreshSource( SelectResult source ) => SourceSelect.Invoke( new SelectResult( SelectResultType.Local, source.Name, source.DisplayString, source.Path ) );
 
         public void ShowReplace() => ReplaceSelect?.Show();
 

--- a/VFXEditor/FileManager/FileManagerBase.cs
+++ b/VFXEditor/FileManager/FileManagerBase.cs
@@ -39,7 +39,7 @@ namespace VfxEditor.FileManager {
 
         public void ShowSource() => SourceSelect?.Show();
 
-        public void RefreshSource( SelectResult source ) => SourceSelect.Invoke( new SelectResult( SelectResultType.Local, source.Name, source.DisplayString, source.Path ) );
+        public void RefreshSource( SelectResult source ) => SourceSelect.Invoke( new SelectResult( source.Type, source.Name, source.DisplayString, source.Path ) );
 
         public void ShowReplace() => ReplaceSelect?.Show();
 

--- a/VFXEditor/FileManager/FileManagerDocument.cs
+++ b/VFXEditor/FileManager/FileManagerDocument.cs
@@ -361,8 +361,13 @@ namespace VfxEditor.FileManager {
                 ImGui.SameLine();
                 using( var font = ImRaii.PushFont( UiBuilder.IconFont ) )
                 {
-                    if( ImGui.Button( FontAwesomeIcon.Sync.ToIconString() ) ) Manager.RefreshSource( Source );
+                    if( ImGui.Button( FontAwesomeIcon.Sync.ToIconString() ) )
+                    {
+                        Manager.RefreshSource( Source );
+                        Dalamud.OkNotification( "Reloaded " + Source.Path );
+                    }
                 }
+                UiUtils.Tooltip( "Reload file" );
             }
         }
 

--- a/VFXEditor/FileManager/FileManagerDocument.cs
+++ b/VFXEditor/FileManager/FileManagerDocument.cs
@@ -356,6 +356,14 @@ namespace VfxEditor.FileManager {
             using( var font = ImRaii.PushFont( UiBuilder.IconFont ) ) {
                 if( ImGui.Button( FontAwesomeIcon.Search.ToIconString() ) ) Manager.ShowSource();
             }
+            if(Source != null && Source.Type == SelectResultType.Local )
+            {
+                ImGui.SameLine();
+                using( var font = ImRaii.PushFont( UiBuilder.IconFont ) )
+                {
+                    if( ImGui.Button( FontAwesomeIcon.Sync.ToIconString() ) ) Manager.RefreshSource( Source );
+                }
+            }
         }
 
         protected void DisplayReplaceBar( float inputSize ) {


### PR DESCRIPTION
![ffxiv_dx11_3Ck09CKhP6](https://github.com/user-attachments/assets/5874bdee-e836-4bcb-8af1-0ef46d208875)
- Use case; I've loaded a local file and it was modified by external means, I want my currently loaded file to reflect those changes without needing to go look for it again.

Button isn't present if the loaded file isn't a local file.