### PR TITLE
Add replace button on VFX curve editor

### DIFF
--- a/VFXEditor/Formats/AvfxFormat/Curve/AvfxCurve.Editor.cs
+++ b/VFXEditor/Formats/AvfxFormat/Curve/AvfxCurve.Editor.cs
@@ -181,11 +181,7 @@ namespace VfxEditor.AvfxFormat {
                 if( UiUtils.DisabledButton( "Paste", CopiedKeys.Count > 0, true ) ) Paste();
 
                 ImGui.SameLine();
-                if( UiUtils.DisabledButton( "Replace", CopiedKeys.Count > 0, true ) )
-                {
-                    Clear();
-                    Paste();
-                }
+                if( UiUtils.DisabledButton( "Replace", CopiedKeys.Count > 0, true ) ) Replace();
 
                 ImGui.SameLine();
                 if( UiUtils.RemoveButton( "Clear", true ) ) Clear();
@@ -301,6 +297,14 @@ namespace VfxEditor.AvfxFormat {
 
         private void Clear() {
             CommandManager.Add( new ListSetCommand<AvfxCurveKey>( Keys, [], Update ) );
+        }
+
+        private void Replace()
+        {
+            var commands = new List<ICommand>();
+            commands.Add( new ListSetCommand<AvfxCurveKey>( Keys, [], Update ) );
+            foreach( var key in CopiedKeys ) commands.Add( new ListAddCommand<AvfxCurveKey>( Keys, new( this, key ) ) );
+            CommandManager.Add( new CompoundCommand( commands, Update ) );
         }
 
         // ======== GRADIENT ==========

--- a/VFXEditor/Formats/AvfxFormat/Curve/AvfxCurve.Editor.cs
+++ b/VFXEditor/Formats/AvfxFormat/Curve/AvfxCurve.Editor.cs
@@ -181,6 +181,13 @@ namespace VfxEditor.AvfxFormat {
                 if( UiUtils.DisabledButton( "Paste", CopiedKeys.Count > 0, true ) ) Paste();
 
                 ImGui.SameLine();
+                if( UiUtils.DisabledButton( "Replace", CopiedKeys.Count > 0, true ) )
+                {
+                    Clear();
+                    Paste();
+                }
+
+                ImGui.SameLine();
                 if( UiUtils.RemoveButton( "Clear", true ) ) Clear();
             }
 


### PR DESCRIPTION
[ffxiv_dx11_u0amdBfORq.webm](https://github.com/user-attachments/assets/8c3104b4-83ad-43bc-a9c2-bf5cd06b6e15)
- Use case; I've copied values from a curve editor and I want to replace them in the current one, without needing to click two buttons (clear + paste) (paste = append)

Additionally, means only one Undo is needed instead of two.

#savecarpaltunnel