### PR TITLE
Add workspace creation from Penumbra mod.

### DIFF
--- a/VFXEditor/FileManager/FileManager.cs
+++ b/VFXEditor/FileManager/FileManager.cs
@@ -99,5 +99,17 @@ namespace VfxEditor.FileManager {
             DraggingItem = null;
             DocumentWindow.Reset();
         }
+
+        public bool AcceptsExt( string path )
+        {
+            return path.EndsWith( Extension );
+        }
+
+        public void PenumbraImport( SelectResult selectedFile, SelectResult replacedFile )
+        {
+            SetSource( selectedFile );
+            SetReplace( replacedFile );
+            AddDocument();
+        }
     }
 }

--- a/VFXEditor/FileManager/FileManagerGroup.cs
+++ b/VFXEditor/FileManager/FileManagerGroup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using VfxEditor.FileManager.Interfaces;
+using VfxEditor.Select;
 using VfxEditor.Utils;
 
 namespace VfxEditor.FileManager {
@@ -124,6 +125,16 @@ namespace VfxEditor.FileManager {
 
         public void Hide() {
             Visible = false;
+        }
+
+        public bool AcceptsExt( string path )
+        {
+            return LastFocusedManager.AcceptsExt(path);
+        }
+
+        public void PenumbraImport( SelectResult selectedFile, SelectResult replacedFile )
+        {
+            LastFocusedManager.PenumbraImport(selectedFile, replacedFile);
         }
     }
 }

--- a/VFXEditor/FileManager/Interfaces/IFileManager.cs
+++ b/VFXEditor/FileManager/Interfaces/IFileManager.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using VfxEditor.Select;
 
 namespace VfxEditor.FileManager.Interfaces {
     public interface IFileManager : IFileManagerSelect {

--- a/VFXEditor/FileManager/Interfaces/IFileManagerGroup.cs
+++ b/VFXEditor/FileManager/Interfaces/IFileManagerGroup.cs
@@ -2,6 +2,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using VfxEditor.Select;
 
 namespace VfxEditor.FileManager.Interfaces {
     public interface IFileManagerGroup {
@@ -42,5 +43,9 @@ namespace VfxEditor.FileManager.Interfaces {
             }
             return false;
         }
+
+        public bool AcceptsExt( string path );
+
+        public void PenumbraImport( SelectResult selectedFile, SelectResult replacedFile );
     }
 }

--- a/VFXEditor/Formats/TextureFormat/TextureManager.cs
+++ b/VFXEditor/Formats/TextureFormat/TextureManager.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using VfxEditor.FileBrowser;
 using VfxEditor.FileManager.Interfaces;
 using VfxEditor.Formats.TextureFormat.Textures;
@@ -12,6 +13,7 @@ using VfxEditor.Select;
 using VfxEditor.Ui;
 using VfxEditor.Ui.Export;
 using VfxEditor.Utils;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace VfxEditor.Formats.TextureFormat {
     public class TextureManager : DalamudWindow, IFileManagerGroup, IFileManagerSelect {
@@ -232,5 +234,15 @@ namespace VfxEditor.Formats.TextureFormat {
         }
 
         public WindowSystem GetWindowSystem() => WindowSystem;
+
+        public bool AcceptsExt( string path )
+        {
+            return path.EndsWith( "atex" );
+        }
+
+        public void PenumbraImport( SelectResult selectedFile, SelectResult replacedFile )
+        {
+            ReplaceTexture( selectedFile.Path, replacedFile.Name );
+        }
     }
 }

--- a/VFXEditor/Plugin.Ui.cs
+++ b/VFXEditor/Plugin.Ui.cs
@@ -80,6 +80,14 @@ namespace VfxEditor {
 
                 ImGui.Separator();
                 if( ImGui.MenuItem( "Settings" ) ) ConfigWindow.Show();
+                if( ImGui.BeginMenu( "Penumbra" ) )
+                {
+                    if( ImGui.MenuItem( "Open Mod" ) ) OpenWorkspacePenumbra( true );
+                    if( ImGui.MenuItem( "Append Mod" ) ) OpenWorkspacePenumbra( false );
+                    ImGui.EndMenu();
+                }
+
+                ImGui.Separator();
                 if( ImGui.MenuItem( "Tools" ) ) ToolsDialog.Show();
                 if( ImGui.BeginMenu( "Help" ) ) {
                     if( ImGui.MenuItem( "Github" ) ) UiUtils.OpenUrl( "https://github.com/0ceal0t/Dalamud-VFXEditor" );

--- a/VFXEditor/Plugin.Workspace.cs
+++ b/VFXEditor/Plugin.Workspace.cs
@@ -13,16 +13,21 @@ using VfxEditor.FileBrowser;
 using VfxEditor.FileManager.Interfaces;
 using VfxEditor.Select;
 using VfxEditor.Ui.Export;
+using VfxEditor.Ui.Import;
 using VfxEditor.Utils;
+using static VfxEditor.Ui.Import.ImportDialog;
 
-namespace VfxEditor {
-    public enum WorkspaceState {
+namespace VfxEditor
+{
+    public enum WorkspaceState
+    {
         None,
         Loading,
         Cleanup
     }
 
-    public partial class Plugin {
+    public partial class Plugin
+    {
         public static readonly Dictionary<string, string> CustomPathBackups = []; // Map of lowercase custom game paths to local paths
 
         public static string CurrentWorkspaceLocation { get; private set; } = "";
@@ -37,14 +42,17 @@ namespace VfxEditor {
         private static DateTime LastAutoSave = DateTime.Now;
 
         // Return true if it's loading and the UI needs to be hidden
-        private static bool CheckLoadState() {
-            if( State == WorkspaceState.Cleanup ) {
+        private static bool CheckLoadState()
+        {
+            if( State == WorkspaceState.Cleanup )
+            {
                 LastAutoSave = DateTime.Now;
                 State = WorkspaceState.None;
                 return true;
             }
 
-            if( State != WorkspaceState.None ) {
+            if( State != WorkspaceState.None )
+            {
                 DrawLoadingDialog();
                 return true;
             }
@@ -52,7 +60,8 @@ namespace VfxEditor {
             return false;
         }
 
-        private static void CheckAutoSave() {
+        private static void CheckAutoSave()
+        {
             if( !Configuration.AutosaveEnabled || Configuration.AutosaveSeconds < 10 ) return;
             if( ( DateTime.Now - LastAutoSave ).TotalSeconds <= Configuration.AutosaveSeconds ) return;
 
@@ -63,15 +72,18 @@ namespace VfxEditor {
             if( string.IsNullOrEmpty( CurrentWorkspaceLocation ) ) return;
 
             Dalamud.Log( "Autosaving workspace..." );
-            if( Configuration.AutosaveBackups ) {
+            if( Configuration.AutosaveBackups )
+            {
                 ExportWorkspace( CurrentWorkspaceLocation.Replace( ".vfxworkspace", $" - {BackupId++ % Configuration.BackupCount}.vfxworkspace" ), false );
             }
             else ExportWorkspace(); // Overwrite current file
         }
 
-        private static async void NewWorkspace() {
+        private static async void NewWorkspace()
+        {
             State = WorkspaceState.Loading;
-            await Task.Run( async () => {
+            await Task.Run( async () =>
+            {
                 await Task.Delay( 100 );
                 WorkspaceFileCount = Groups.Count - 1;
                 foreach( var manager in Groups.Where( x => x != null ) ) manager.Reset( false );
@@ -84,20 +96,82 @@ namespace VfxEditor {
             } );
         }
 
+        private static void OpenWorkspacePenumbra( bool reset )
+        {
+            ImportDialog.SetReset( reset );
+            ImportDialog.SetCallback( CreateWorkspaceFromPenumbra );
+            ImportDialog.Show();
+        }
+
+        private static async void CreateWorkspaceFromPenumbra( ImportResult res )
+        {
+            State = WorkspaceState.Loading;
+            var mod = res.Mod;
+
+            var loadCount = 0;
+            foreach( var option in mod.SourceFiles )
+            {
+                foreach( var file in option.Value )
+                {
+                    loadCount++;
+                }
+            }
+            WorkspaceFileCount = loadCount;
+            await Task.Run( () =>
+            {
+                if( res.Reset )
+                {
+                    foreach( var manager in Groups.Where( x => x != null ) ) manager.Reset( false );
+                }
+                foreach( var option in mod.SourceFiles )
+                {
+                    var optionName = option.Key;
+                    if( !res.Options.Contains( optionName ) ) continue;
+
+                    foreach( var file in option.Value )
+                    {
+                        var gamePath = "";
+                        var filePath = "";
+                        if( file.Contains( '|' ) )
+                        {
+                            var split = file.Split( "|" );
+                            gamePath = split[0];
+                            filePath = split[1];
+                        }
+                        var selectedFile = new SelectResult( SelectResultType.Local, gamePath, $"[PEN] {optionName} : {gamePath}", filePath );
+                        var replacedFile = new SelectResult( SelectResultType.Local, gamePath, $"{gamePath}", gamePath );
+                        foreach( var manager in Groups.Where( x => x != null ) )
+                        {
+                            if( manager.AcceptsExt( gamePath ) )
+                            {
+                                manager.PenumbraImport( selectedFile, replacedFile );
+                                Dalamud.Log( "Imported " + selectedFile.Path );
+                            }
+                        }
+                    }
+                }
+            } );
+            State = WorkspaceState.None;
+        }
+
         private static void OpenWorkspace( bool reset ) {
             FileBrowserManager.OpenFileDialog( "Select a Workspace File", "Workspace{.vfxworkspace,.json},.*", ( ok, res ) => {
                 if( !ok ) return;
-                try {
+                try
+                {
                     var extension = new FileInfo( res ).Extension;
-                    if( extension == ".json" ) { // OLD
+                    if( extension == ".json" )
+                    { // OLD
                         var directory = Path.GetDirectoryName( res );
                         OpenWorkspaceAsync( directory.TrimEnd( Path.DirectorySeparatorChar ) + ".vfxworkspace", Path.GetDirectoryName( res ), false, reset ); // Move to new format
                     }
-                    else if( extension == ".vfxworkspace" ) { // NEW
+                    else if( extension == ".vfxworkspace" )
+                    { // NEW
                         OpenWorkspaceAsync( res, reset );
                     }
                 }
-                catch( Exception e ) {
+                catch( Exception e )
+                {
                     Dalamud.Error( e, "Could not load workspace" );
                 }
             } );
@@ -105,19 +179,23 @@ namespace VfxEditor {
 
         private static void OpenWorkspaceAsync( string loadLocation, bool reset ) => OpenWorkspaceAsync( loadLocation, Path.Combine( Path.GetDirectoryName( loadLocation ), "VFX_WORKSPACE_IN" ), true, reset );
 
-        private static void OpenWorkspaceAsync( string loadLocation, string tempDir, bool unzip, bool reset ) {
+        private static void OpenWorkspaceAsync( string loadLocation, string tempDir, bool unzip, bool reset )
+        {
             State = WorkspaceState.Loading;
-            Task.Run( async () => {
+            Task.Run( async () =>
+            {
                 await Task.Delay( 100 );
                 if( unzip ) ZipFile.ExtractToDirectory( loadLocation, tempDir, true );
 
-                if( OpenWorkspaceFolder( tempDir, reset ) ) {
+                if( OpenWorkspaceFolder( tempDir, reset ) )
+                {
                     CurrentWorkspaceLocation = loadLocation;
                     BackupId = 0;
                     Configuration.AddRecentWorkspace( loadLocation );
                     State = WorkspaceState.Cleanup;
                 }
-                else {
+                else
+                {
                     State = WorkspaceState.None;
                 }
 
@@ -125,12 +203,14 @@ namespace VfxEditor {
             } );
         }
 
-        private static bool OpenWorkspaceFolder( string loadLocation, bool reset ) {
+        private static bool OpenWorkspaceFolder( string loadLocation, bool reset )
+        {
             WorkspaceFileCount = Directory.GetFiles( loadLocation, "*.*", SearchOption.AllDirectories ).Length;
             Dalamud.Log( $"Loading {WorkspaceFileCount} files from {loadLocation}" );
 
             var metaPath = Path.Combine( loadLocation, "vfx_workspace.json" );
-            if( !File.Exists( metaPath ) ) {
+            if( !File.Exists( metaPath ) )
+            {
                 Dalamud.Error( "vfx_workspace.json does not exist" );
                 return false;
             }
@@ -165,7 +245,8 @@ namespace VfxEditor {
 
                 var drawList = ImGui.GetWindowDrawList();
                 drawList.AddRectFilled( pos, pos + new Vector2( width, height ), ImGui.GetColorU32( ImGuiCol.FrameBg ), 5f );
-                if( count > 0 ) {
+                if( count > 0 )
+                {
                     drawList.AddRectFilled( pos, pos + new Vector2( filled, height ), ImGui.ColorConvertFloat4ToU32( UiUtils.PARSED_GREEN ), 5f );
                 }
 
@@ -175,7 +256,8 @@ namespace VfxEditor {
 
         // =================================
 
-        private static void SaveWorkspace() {
+        private static void SaveWorkspace()
+        {
             if( string.IsNullOrEmpty( CurrentWorkspaceLocation ) ) SaveAsWorkspace();
             else ExportWorkspace();
         }
@@ -188,15 +270,19 @@ namespace VfxEditor {
             } );
         }
 
-        private static void ExportWorkspace( string location = null, bool updateLocation = true ) {
-            Task.Run( async () => {
-                if( !await SavingLock.WaitAsync( 1000 ) ) {
+        private static void ExportWorkspace( string location = null, bool updateLocation = true )
+        {
+            Task.Run( async () =>
+            {
+                if( !await SavingLock.WaitAsync( 1000 ) )
+                {
                     Dalamud.Error( "Could not get lock" );
                     return;
                 }
                 Saving = true;
 
-                try {
+                try
+                {
                     var workspaceLocation = string.IsNullOrEmpty( location ) ? CurrentWorkspaceLocation : location;
 
                     var saveLocation = Path.Combine( Path.GetDirectoryName( workspaceLocation ), "VFX_WORKSPACE_OUT" );
@@ -215,12 +301,14 @@ namespace VfxEditor {
                     Dalamud.Log( $"Saved to {workspaceLocation}" );
                     Directory.Delete( saveLocation, true );
 
-                    if( updateLocation ) {
+                    if( updateLocation )
+                    {
                         CurrentWorkspaceLocation = workspaceLocation;
                         BackupId = 0;
                     }
                 }
-                catch( Exception ex ) {
+                catch( Exception ex )
+                {
                     Dalamud.Error( ex, "Error saving workspace" );
                 }
 
@@ -231,17 +319,20 @@ namespace VfxEditor {
 
         // =======================
 
-        public static void AddCustomBackupLocation( SelectResult result, string localPath ) {
+        public static void AddCustomBackupLocation( SelectResult result, string localPath )
+        {
             if( result == null || result.Type == SelectResultType.Local ) return;
             AddCustomBackupLocation( result.Path, localPath );
         }
 
-        public static void AddCustomBackupLocation( string gamePath, string localPath ) {
+        public static void AddCustomBackupLocation( string gamePath, string localPath )
+        {
             if( string.IsNullOrEmpty( gamePath ) || string.IsNullOrEmpty( localPath ) ) return;
             if( Dalamud.GameFileExists( gamePath ) ) return; // not a custom path
 
             CustomPathBackups[gamePath.ToLower()] = localPath;
-            if( Configuration?.LogDebug == true ) {
+            if( Configuration?.LogDebug == true )
+            {
                 Dalamud.Log( "[CUSTOM]" );
                 foreach( var (game, local) in CustomPathBackups ) Dalamud.Log( $" {game} -> {local}" );
             }

--- a/VFXEditor/Plugin.cs
+++ b/VFXEditor/Plugin.cs
@@ -31,6 +31,7 @@ using VfxEditor.Library;
 using VfxEditor.Spawn;
 using VfxEditor.Tracker;
 using VfxEditor.Ui.Export;
+using VfxEditor.Ui.Import;
 using VfxEditor.Ui.Tools;
 
 namespace VfxEditor {
@@ -45,6 +46,7 @@ namespace VfxEditor {
 
         public static PenumbraIpc PenumbraIpc { get; private set; }
         public static PenumbraDialog PenumbraDialog { get; private set; }
+        public static ImportDialog ImportDialog { get; private set; }
 
         public static WindowSystem WindowSystem { get; private set; }
 
@@ -140,6 +142,7 @@ namespace VfxEditor {
             DirectXManager = new();
             TrackerManager = new();
             LibraryManager = new();
+            ImportDialog = new();
 
             Dalamud.Framework.Update += FrameworkOnUpdate;
             Dalamud.PluginInterface.UiBuilder.Draw += Draw;

--- a/VFXEditor/Select/Penumbra/SelectPenumbraTab.cs
+++ b/VFXEditor/Select/Penumbra/SelectPenumbraTab.cs
@@ -4,16 +4,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using VfxEditor.Ui.Export;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Select.Penumbra {
-    public class SelectedPenumbraMod {
-        public Dictionary<string, List<string>> SourceFiles;
-        public Dictionary<string, List<string>> ReplaceFiles;
-        public PenumbraMeta Meta;
-    }
-
-    public class SelectPenumbraTab : SelectTab<SelectPenumbraTabItem, SelectedPenumbraMod> {
+    public class SelectPenumbraTab : SelectTab<SelectPenumbraTabItem, PenumbraMod> {
         public SelectPenumbraTab( SelectDialog dialog ) : base( dialog, "Penumbra", "Penumbra-Shared" ) { }
 
         protected override bool IsDisabled() => !Plugin.PenumbraIpc.PenumbraEnabled;
@@ -32,67 +26,9 @@ namespace VfxEditor.Select.Penumbra {
         }
 
         // $"{group} {option}" -> (gamePath, localPath)
-        public override void LoadSelection( SelectPenumbraTabItem item, out SelectedPenumbraMod loaded ) {
+        public override void LoadSelection( SelectPenumbraTabItem item, out PenumbraMod loaded ) {
             loaded = new();
-            var files = new Dictionary<string, List<(string, string)>>();
-
-            var baseModPath = Plugin.PenumbraIpc.GetModDirectory();
-            if( string.IsNullOrEmpty( baseModPath ) ) return;
-
-            try {
-                var modPath = Path.Join( baseModPath, Selected.Name );
-                loaded.Meta = JsonConvert.DeserializeObject<PenumbraMeta>( File.ReadAllText( Path.Join( modPath, "meta.json" ) ) );
-
-                var modFiles = Directory.GetFiles( modPath ).Where( x => x.EndsWith( ".json" ) && !x.EndsWith( "meta.json" ) );
-                foreach( var modFile in modFiles ) {
-                    try {
-                        var modFileName = Path.GetFileName( modFile ).Replace( ".json", "" );
-                        if( modFileName == "default_mod" ) {
-                            var mod = JsonConvert.DeserializeObject<PenumbraModStruct>( File.ReadAllText( modFile ) );
-                            if( mod.Files != null ) {
-                                var defaultFiles = new List<(string, string)>();
-                                AddToFiles( mod?.Files, defaultFiles, modPath );
-                                files["default_mod"] = defaultFiles;
-                            }
-                        }
-                        else {
-                            var group = JsonConvert.DeserializeObject<PenumbraGroupStruct>( File.ReadAllText( modFile ) );
-                            if( group.Options != null ) {
-                                foreach( var option in group.Options.Where( x => x.Files != null ) ) {
-                                    var optionFiles = new List<(string, string)>();
-                                    AddToFiles( option?.Files, optionFiles, modPath );
-                                    files[$"{group.Name} / {option.Name}"] = optionFiles;
-                                }
-                            }
-                        }
-                    }
-                    catch( Exception e ) {
-                        Dalamud.Error( e, modFile );
-                    }
-                }
-            }
-            catch( Exception e ) {
-                Dalamud.Error( e, "Error reading Penumbra mods" );
-            }
-
-            loaded.SourceFiles = files.ToDictionary(
-                x => x.Key,
-                x => x.Value.Where( y => Path.Exists( y.Item2 ) ).Select( y => $"{y.Item1}|{y.Item2}" ).ToList() // actually use local path
-            );
-
-            loaded.ReplaceFiles = files.ToDictionary(
-                x => x.Key,
-                x => x.Value.Select( y => y.Item1 ).ToList()
-            );
-        }
-
-        private void AddToFiles( Dictionary<string, string> filesToAdd, List<(string, string)> files, string modPath ) {
-            if( filesToAdd == null ) return;
-
-            foreach( var (gamePath, localFile) in filesToAdd ) {
-                if( !Dialog.Extensions.Any( gamePath.EndsWith ) ) continue;
-                files.Add( (gamePath, Path.Join( modPath, localFile )) );
-            }
+            PenumbraUtils.LoadFromName( item.Name, Dialog.Extensions, out loaded );
         }
 
         protected override void DrawSelected() {

--- a/VFXEditor/Ui/Import/ImportDialog.cs
+++ b/VFXEditor/Ui/Import/ImportDialog.cs
@@ -1,0 +1,463 @@
+using Dalamud.Interface.Utility.Raii;
+using Dalamud.Bindings.ImGui;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Numerics;
+using VfxEditor.Select.Base;
+using VfxEditor.Utils;
+
+namespace VfxEditor.Ui.Import
+{
+    public class ImportDialog : DalamudWindow
+    {
+        protected readonly List<string> AllowedTypes = ["avfx", "atex", "tmb", "pap", "scd", "uld", "sklb", "skp", "phyb", "eid", "atch", "kdb", "pbd", "mdl", "mtrl", "shpk", "shcd"];
+
+        protected readonly List<PenumbraItem> Items = new();
+
+        protected readonly string Name;
+
+        protected Action<ImportResult> Callback;
+
+        protected Vector2 DefaultWindowPadding = new();
+
+        protected PenumbraMod LoadedPenumbraMod;
+        protected bool Reset = false;
+        protected ImportResult Result = new();
+
+        protected string SearchInput = "";
+
+        protected Dictionary<string, bool> SelectedModOptions = [];
+        protected PenumbraItem SelectedPenumbraMod;
+        protected Dictionary<string, bool> SelectedTypes = [];
+
+        public ImportDialog() : base( "Import from Penumbra", false, new( 800, 600 ), Plugin.WindowSystem )
+        {
+            foreach( var type in AllowedTypes )
+            {
+                SelectedTypes.Add( type, false );
+            }
+            ResetSelectedTypes();
+        }
+
+        public override void DrawBody()
+        {
+            Load(); // mods can change externally
+            if( Items.Count == 0 ) return;
+
+            using var _ = ImRaii.PushId( WindowName );
+
+            DefaultWindowPadding = ImGui.GetStyle().WindowPadding;
+
+            ImGui.InputTextWithHint( "##Search", "Search", ref SearchInput, 255 );
+            ImGui.Separator();
+
+            if( ImGui.CollapsingHeader( "Extensions" ) )
+            {
+                DrawExtensionsBasic();
+                ImGui.SameLine();
+                DrawExtensionPicker();
+            }
+            if( ImGui.CollapsingHeader( "Mods", ImGuiTreeNodeFlags.DefaultOpen ) )
+            {
+                using var style = ImRaii.PushStyle( ImGuiStyleVar.WindowPadding, new Vector2( 0, 0 ) );
+                using var table = ImRaii.Table( "ModsTable", 2, ImGuiTableFlags.Resizable | ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.NoHostExtendY, new( -1, ImGui.GetContentRegionAvail().Y ) );
+                if( !table ) return;
+                style.Dispose();
+
+                ImGui.TableSetupColumn( "##Left", ImGuiTableColumnFlags.WidthFixed, 200 );
+                ImGui.TableSetupColumn( "##Right", ImGuiTableColumnFlags.WidthStretch );
+
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                using( var tree = ImRaii.Child( "ModsList" ) )
+                {
+                    DrawModsTable();
+                }
+
+                ImGui.TableNextColumn();
+                ImGui.Separator();
+                if( SelectedPenumbraMod == null ) ImGui.Text( "Select a mod or double click it to import all options..." );
+                else
+                {
+                    DrawModDesc();
+                    DrawButtonsDesc();
+                }
+            }
+        }
+
+        public void SetCallback( Action<ImportResult> callback )
+        {
+            Callback = callback;
+        }
+
+        public void SetReset( bool reset )
+        {
+            Reset = reset;
+        }
+
+        private void DrawButtonsDesc()
+        {
+            ImGui.Separator();
+            var text = Reset ? "Import Modpack into Workspace" : "Append Modpack to Workspace";
+            if( ImGui.Button( text ) )
+            {
+                OnImport();
+            }
+        }
+
+        private void DrawExtensionButtons()
+        {
+            if( ImGui.Button( "Select All Extensions" ) )
+            {
+                ExtensionSelectAll();
+            }
+            ImGui.SameLine();
+            if( ImGui.Button( "Unselect All" ) )
+            {
+                ExtensionSelectNone();
+            }
+        }
+
+        private void DrawExtensionPicker()
+        {
+            ImGui.BeginChild( "ExtAdvanced", new Vector2( -1, ImGui.GetContentRegionAvail().Y * .3f ) );
+            DrawExtensionButtons();
+            if( ImGui.BeginListBox( "##Extensions", new Vector2( -1, -1 ) ) )
+            {
+                foreach( var type in SelectedTypes )
+                {
+                    if( ImGui.Selectable( type.Key, type.Value, ImGuiSelectableFlags.None ) )
+                    {
+                        ToggleType( type.Key );
+                    }
+                }
+                ImGui.EndListBox();
+            }
+            ImGui.EndChild();
+        }
+
+        private void DrawExtensionsBasic()
+        {
+            var vfxCheck = SelectedTypes["avfx"] && SelectedTypes["atex"];
+            var aniCheck = SelectedTypes["tmb"] && SelectedTypes["pap"];
+            var sndCheck = SelectedTypes["scd"];
+            var modCheck = SelectedTypes["mdl"] && SelectedTypes["mtrl"];
+            var uiPicker = SelectedTypes["uld"];
+
+            ImGui.BeginChild( "ExtBasic", new Vector2( ImGui.GetContentRegionAvail().X * .4f, ImGui.GetContentRegionAvail().Y * .3f ) );
+            ImGui.Text( "Quick Picker" );
+            if( ImGui.Checkbox( "VFX", ref vfxCheck ) )
+            {
+                var toggle = vfxCheck;
+                SelectedTypes["avfx"] = toggle;
+                SelectedTypes["atex"] = toggle;
+                RefreshLoadedMod();
+            }
+            if( ImGui.Checkbox( "Animation", ref aniCheck ) )
+            {
+                var toggle = aniCheck;
+                SelectedTypes["tmb"] = toggle;
+                SelectedTypes["pap"] = toggle;
+                RefreshLoadedMod();
+            }
+            if( ImGui.Checkbox( "Sound", ref sndCheck ) )
+            {
+                var toggle = sndCheck;
+                SelectedTypes["scd"] = toggle;
+                RefreshLoadedMod();
+            }
+            if( ImGui.Checkbox( "Model", ref modCheck ) )
+            {
+                var toggle = modCheck;
+                SelectedTypes["mdl"] = toggle;
+                SelectedTypes["mtrl"] = toggle;
+                RefreshLoadedMod();
+            }
+            if( ImGui.Checkbox( "UI", ref uiPicker ) )
+            {
+                var toggle = uiPicker;
+                SelectedTypes["uld"] = toggle;
+                RefreshLoadedMod();
+            }
+            ImGui.EndChild();
+        }
+
+        private void DrawModBtn()
+        {
+            if( ImGui.Button( "Select All Options" ) )
+            {
+                OptionsSelectAll();
+            }
+            ImGui.SameLine();
+            if( ImGui.Button( "Unselect All" ) )
+            {
+                OptionsSelectNone();
+            }
+        }
+
+        private void DrawModDesc()
+        {
+            ImGui.BeginChild( "ModDesc", new Vector2( ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y * .9f ) );
+            ImGui.Text( SelectedPenumbraMod.GetName() );
+            ImGui.SetCursorPosY( ImGui.GetCursorPosY() + 5 );
+            if( LoadedPenumbraMod.Meta != null )
+            {
+                ImGui.TextDisabled( $"by {LoadedPenumbraMod.Meta.Author}" );
+            }
+            DrawModBtn();
+            DrawModOptions();
+            ImGui.EndChild();
+        }
+
+        private void DrawModOptions()
+        {
+            var idx = 0;
+            foreach( var option in LoadedPenumbraMod.SourceFiles )
+            {
+                var optionName = option.Key;
+                var selected = SelectedModOptions[optionName];
+                if( ImGui.Checkbox( "##SelectedOption" + idx, ref selected ) )
+                {
+                    ToggleSelectedOption( optionName );
+                }
+                ImGui.SameLine();
+                if( ImGui.CollapsingHeader( optionName, ImGuiTreeNodeFlags.DefaultOpen ) )
+                {
+                    if( selected ) DrawModPaths( option.Value );
+                    else DrawModPathsDisabled( option.Value );
+                }
+                idx++;
+            }
+        }
+
+        private void DrawModPaths( List<string> option )
+        {
+            foreach( var path in option )
+            {
+                var split = path.Split( '|' );
+                var gamePath = split[0];
+                var filePath = split[1];
+
+                ImGui.SetCursorPosX( ImGui.GetCursorPosX() + 32 );
+                ImGui.Text( gamePath );
+                if( ImGui.IsItemHovered() )
+                {
+                    ImGui.SetTooltip( filePath );
+                }
+            }
+        }
+
+        private void DrawModPathsDisabled( List<string> option )
+        {
+            foreach( var path in option )
+            {
+                var split = path.Split( '|' );
+                var gamePath = split[0];
+                var filePath = split[1];
+
+                ImGui.SetCursorPosX( ImGui.GetCursorPosX() + 32 );
+                ImGui.TextDisabled( gamePath );
+                if( ImGui.IsItemHovered() )
+                {
+                    ImGui.SetTooltip( filePath );
+                }
+            }
+        }
+
+        private void DrawModsTable()
+        {
+            using var style = ImRaii.PushStyle( ImGuiStyleVar.CellPadding, new Vector2( 0, 3 ) );
+            using var padding = ImRaii.PushStyle( ImGuiStyleVar.WindowPadding, new Vector2( 8, 3 ) );
+            using var child = ImRaii.Child( "ModsListRow", new Vector2( -1, -1 ), true );
+            using var table = ImRaii.Table( "ModsList", 3, ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingFixedFit );
+            if( !table ) return;
+            padding.Dispose();
+
+            ImGui.TableSetupColumn( "##Column1", ImGuiTableColumnFlags.WidthStretch );
+
+            var idx = 0;
+            foreach( var item in Items )
+            {
+                if( !( string.IsNullOrEmpty( SearchInput ) ||
+                    item.Name.Contains( SearchInput, System.StringComparison.CurrentCultureIgnoreCase )
+                ) ) continue;
+                ImGui.TableNextRow();
+                DrawRow( item, idx );
+                idx++;
+            }
+        }
+
+        private bool DrawRow( PenumbraItem item, int idx )
+        {
+            using var _ = ImRaii.PushId( idx );
+
+            ImGui.TableNextColumn();
+            if( ImGui.Selectable( item.Name, SelectedPenumbraMod?.Name == item.Name, ImGuiSelectableFlags.SpanAllColumns ) )
+            {
+                SelectedPenumbraMod = item;
+                OnRefresh();
+            }
+
+            if( PostRow( item, idx ) ) return true;
+            return false;
+        }
+
+        private void ExtensionSelectAll()
+        {
+            foreach( var type in SelectedTypes )
+            {
+                SelectedTypes[type.Key] = true;
+            }
+            OnRefresh();
+        }
+
+        private void ExtensionSelectNone()
+        {
+            foreach( var type in SelectedTypes )
+            {
+                SelectedTypes[type.Key] = false;
+            }
+            OnRefresh();
+        }
+
+        private List<string> GetSelectedTypes()
+        {
+            var typesList = new List<string>();
+            foreach( var type in SelectedTypes )
+            {
+                if( type.Value ) typesList.Add( type.Key );
+            }
+
+            return typesList;
+        }
+
+        private void Load()
+        {
+            LoadData();
+        }
+
+        private void LoadData()
+        {
+            Items.Clear();
+            Items.AddRange( Plugin.PenumbraIpc.GetMods().Select( x => new PenumbraItem( x ) ) );
+        }
+
+        private void OnImport()
+        {
+            Result = new();
+            Result.Extensions = GetSelectedTypes();
+            Result.Reset = Reset;
+            Result.Mod = LoadedPenumbraMod;
+            var listOptions = new List<string>();
+            foreach( var option in SelectedModOptions )
+            {
+                if( option.Value ) listOptions.Add( option.Key );
+            }
+            Result.Options = listOptions;
+            Callback( Result );
+            Hide();
+        }
+
+        private void OnRefresh()
+        {
+            RefreshLoadedMod();
+        }
+
+        private void OptionsReset()
+        {
+            SelectedModOptions = [];
+            foreach( var source in LoadedPenumbraMod.SourceFiles )
+            {
+                SelectedModOptions.Add( source.Key, true );
+            }
+        }
+
+        private void OptionsSelectAll()
+        {
+            foreach( var option in SelectedModOptions )
+            {
+                SelectedModOptions[option.Key] = true;
+            }
+        }
+
+        private void OptionsSelectNone()
+        {
+            foreach( var option in SelectedModOptions )
+            {
+                SelectedModOptions[option.Key] = false;
+            }
+        }
+
+        private bool PostRow( PenumbraItem item, int idx )
+        {
+            if( ImGui.IsMouseDoubleClicked( ImGuiMouseButton.Left ) && ImGui.IsItemHovered() )
+            {
+                OnImport();
+                return true;
+            }
+
+            return false;
+        }
+
+        private void RefreshLoadedMod()
+        {
+            if( SelectedPenumbraMod == null ) return;
+            var sameMod = LoadedPenumbraMod != null && LoadedPenumbraMod.Meta != null && SelectedPenumbraMod.Name == LoadedPenumbraMod.Meta.Name;
+            LoadedPenumbraMod = new();
+            PenumbraUtils.LoadFromName( SelectedPenumbraMod.Name, GetSelectedTypes(), out LoadedPenumbraMod );
+            if( !sameMod )
+            {
+                OptionsReset();
+            }
+        }
+
+        private void ResetSelectedTypes()
+        {
+            SelectedTypes["avfx"] = true;
+            SelectedTypes["atex"] = true;
+            SelectedTypes["pap"] = true;
+            SelectedTypes["tmb"] = true;
+            SelectedTypes["scd"] = true;
+            SelectedTypes["mdl"] = true;
+            SelectedTypes["mtrl"] = true;
+            SelectedTypes["uld"] = true;
+        }
+
+        private void ToggleSelectedOption( string name )
+        {
+            SelectedModOptions[name] = !SelectedModOptions[name];
+        }
+
+        private void ToggleType( string key )
+        {
+            SelectedTypes[key] = !SelectedTypes[key];
+            OnRefresh();
+        }
+
+        public class ImportResult
+        {
+            public List<string> Extensions;
+            public PenumbraMod Mod;
+            public List<string> Options;
+            public bool Reset;
+
+            public ImportResult()
+            { }
+        }
+
+        public class PenumbraItem : ISelectItem
+        {
+            public readonly string Name;
+
+            public PenumbraItem( string name )
+            {
+                Name = name;
+            }
+
+            public string GetName() => Name;
+        }
+    }
+}

--- a/VFXEditor/Utils/PenumbraUtils.cs
+++ b/VFXEditor/Utils/PenumbraUtils.cs
@@ -1,7 +1,18 @@
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using VfxEditor.Ui.Export;
 
 namespace VfxEditor.Utils {
+    public class PenumbraMod
+    {
+        public Dictionary<string, List<string>> SourceFiles;
+        public Dictionary<string, List<string>> ReplaceFiles;
+        public PenumbraMeta Meta;
+    }
+
     public static class PenumbraUtils {
         public static void WriteBytes( byte[] data, string modRootFolder, string groupOption, string gamePath, Dictionary<string, string> files ) {
             var filePath = string.IsNullOrEmpty( groupOption ) ? gamePath : Path.Combine( groupOption.ToLower(), gamePath );
@@ -19,6 +30,83 @@ namespace VfxEditor.Utils {
             File.Copy( localPath, path, true );
 
             files[gamePath] = filePath.Replace( '/', '\\' );
+        }
+
+        // $"{group} {option}" -> (gamePath, localPath)
+        public static void LoadFromName( string itemName, List<string> extensions, out PenumbraMod loaded )
+        {
+            loaded = new();
+            var files = new Dictionary<string, List<(string, string)>>();
+
+            var baseModPath = Plugin.PenumbraIpc.GetModDirectory();
+            if( string.IsNullOrEmpty( baseModPath ) ) return;
+
+            try
+            {
+                var modPath = Path.Join( baseModPath, itemName );
+                loaded.Meta = JsonConvert.DeserializeObject<PenumbraMeta>( File.ReadAllText( Path.Join( modPath, "meta.json" ) ) );
+
+                var modFiles = Directory.GetFiles( modPath ).Where( x => x.EndsWith( ".json" ) && !x.EndsWith( "meta.json" ) );
+                foreach( var modFile in modFiles )
+                {
+                    try
+                    {
+                        var modFileName = Path.GetFileName( modFile ).Replace( ".json", "" );
+                        if( modFileName == "default_mod" )
+                        {
+                            var mod = JsonConvert.DeserializeObject<PenumbraModStruct>( File.ReadAllText( modFile ) );
+                            if( mod.Files != null )
+                            {
+                                var defaultFiles = new List<(string, string)>();
+                                AddToFiles( mod?.Files, defaultFiles, modPath, extensions );
+                                files["default_mod"] = defaultFiles;
+                            }
+                        }
+                        else
+                        {
+                            var group = JsonConvert.DeserializeObject<PenumbraGroupStruct>( File.ReadAllText( modFile ) );
+                            if( group.Options != null )
+                            {
+                                foreach( var option in group.Options.Where( x => x.Files != null ) )
+                                {
+                                    var optionFiles = new List<(string, string)>();
+                                    AddToFiles( option?.Files, optionFiles, modPath, extensions );
+                                    files[$"{group.Name} / {option.Name}"] = optionFiles;
+                                }
+                            }
+                        }
+                    }
+                    catch( Exception e )
+                    {
+                        Dalamud.Error( e, modFile );
+                    }
+                }
+            }
+            catch( Exception e )
+            {
+                Dalamud.Error( e, "Error reading Penumbra mods" );
+            }
+
+            loaded.SourceFiles = files.ToDictionary(
+                x => x.Key,
+                x => x.Value.Where( y => Path.Exists( y.Item2 ) ).Select( y => $"{y.Item1}|{y.Item2}" ).ToList() // actually use local path
+            );
+
+            loaded.ReplaceFiles = files.ToDictionary(
+                x => x.Key,
+                x => x.Value.Select( y => y.Item1 ).ToList()
+            );
+        }
+
+        public static void AddToFiles( Dictionary<string, string> filesToAdd, List<(string, string)> files, string modPath, List<string> extensions )
+        {
+            if( filesToAdd == null ) return;
+
+            foreach( var (gamePath, localFile) in filesToAdd )
+            {
+                if( !extensions.Any( gamePath.EndsWith ) ) continue;
+                files.Add( (gamePath, Path.Join( modPath, localFile )) );
+            }
         }
     }
 }


### PR DESCRIPTION
- Use case; I want to edit a Penumbra mod but I don't have an existing workspace.
                   I want to append an existing Penumbra mod to my workspace

[ffxiv_dx11_nzMXRg4FvQ.webm](https://github.com/user-attachments/assets/3ca532d1-54a2-4c59-8da1-21ebfda83fd0)

- I can select by file extension or all of them, the more common file types are pre-selected. All VFXEditor editable files selectable.

[ffxiv_dx11_aA5rrrrDj2.webm](https://github.com/user-attachments/assets/07b5eeb0-b74e-4cac-90a9-78d3a6391a50)

- I can select by modpack option or all of them. Replaced path can end up being duplicate, user be wary.

[ffxiv_dx11_LbC8WXt65U.webm](https://github.com/user-attachments/assets/7d12df00-baa6-41d8-8790-fcce0b99653c)

[ffxiv_dx11_9sLD8q4h2j.webm](https://github.com/user-attachments/assets/69ce17a6-99d6-4348-a5fa-337139d68929)
