### PR TITLE
Parse Axis Connect Random as AxisConnect + differentiate AxisConnect3 from AxisConnect2

### DIFF
--- a/VFXEditor/Formats/AvfxFormat/Base/Enums.cs
+++ b/VFXEditor/Formats/AvfxFormat/Base/Enums.cs
@@ -289,7 +289,15 @@ namespace VfxEditor.AvfxFormat {
             Linear = 1,
             Step = 2
         }
-        public enum AxisConnect {
+
+        public enum AxisConnect2
+        {
+            None = 0,
+            X_Y = 1,
+            Y_X = 2
+        }
+
+        public enum AxisConnect3 {
             None = 0,
             X_YZ = 1,
             X_Y = 2,

--- a/VFXEditor/Formats/AvfxFormat/Curve/AvfxCurve2Axis.cs
+++ b/VFXEditor/Formats/AvfxFormat/Curve/AvfxCurve2Axis.cs
@@ -6,8 +6,8 @@ using static VfxEditor.AvfxFormat.Enums;
 
 namespace VfxEditor.AvfxFormat {
     public class AvfxCurve2Axis : AvfxCurveBase {
-        public readonly AvfxEnum<AxisConnect> AxisConnectType = new( "Axis Connect", "ACT" );
-        public readonly AvfxEnum<RandomType> AxisConnectRandomType = new( "Axis Connect Random", "ACTR" );
+        public readonly AvfxEnum<AxisConnect2> AxisConnectType = new( "Axis Connect", "ACT" );
+        public readonly AvfxEnum<AxisConnect2> AxisConnectRandomType = new( "Axis Connect Random", "ACTR" );
         public readonly AvfxCurve X;
         public readonly AvfxCurve Y;
         public readonly AvfxCurve RX;

--- a/VFXEditor/Formats/AvfxFormat/Curve/AvfxCurve3Axis.cs
+++ b/VFXEditor/Formats/AvfxFormat/Curve/AvfxCurve3Axis.cs
@@ -6,8 +6,8 @@ using static VfxEditor.AvfxFormat.Enums;
 
 namespace VfxEditor.AvfxFormat {
     public class AvfxCurve3Axis : AvfxCurveBase {
-        public readonly AvfxEnum<AxisConnect> AxisConnectType = new( "Axis Connect", "ACT" );
-        public readonly AvfxEnum<RandomType> AxisConnectRandomType = new( "Axis Connect Random", "ACTR" );
+        public readonly AvfxEnum<AxisConnect3> AxisConnectType = new( "Axis Connect", "ACT" );
+        public readonly AvfxEnum<AxisConnect3> AxisConnectRandomType = new( "Axis Connect Random", "ACTR" );
         public readonly AvfxCurve X;
         public readonly AvfxCurve Y;
         public readonly AvfxCurve Z;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/47483b65-41c7-4273-8e1a-4e81516995f5)
Found on Oka - vfx/ws/2kt_ws_s09/eff/2kt_ws09c0t.avfx

Parsed as AxisConnect we get 
![image](https://github.com/user-attachments/assets/caeea0d3-6387-4390-b8b0-82a4080b5189)
Which corresponds to what's happening in game

I've also previously tested it(and used it extensively) for "FirstPlus", which is X_YZ with AxisConnect, and got the expected result of connecting Random X to YZ
I think it should be safe to assume that is how it works.

------------
Additionally, looking at the code using AxisConnect, I've noticed it was used in UV curves, however UV only have X/Y so I took the liberty of creating a specific type for them. And yes, using an axis connect value that would be for Z here crashes the game upon spawn.

