### PR TITLE
try to gracefully fail MDL PopulateIndexData

### DIFF
--- a/VFXEditor/Formats/MdlFormat/Mesh/Base/MdlMeshData.cs
+++ b/VFXEditor/Formats/MdlFormat/Mesh/Base/MdlMeshData.cs
@@ -28,6 +28,12 @@ namespace VfxEditor.Formats.MdlFormat.Mesh.Base {
         }
 
         protected void PopulateIndexData( MdlFileData data, BinaryReader reader, int lod ) {
+            // prevents total failure to load MDL if index buffer is malformed for LOD
+            // TODO: why/when does this happen when enqueueing?
+            if( data.IndexBufferPositions[lod].Count == 0) {
+                Dalamud.Error($"IndexBufferPositions Queue empty for LOD #{lod}, aborting populate");
+                return;
+            }
             var padding = data.IndexBufferPositions[lod].Dequeue() - ( ( IndexCount * 2 ) + _IndexOffset );
             reader.BaseStream.Position = data.IndexBufferOffsets[lod] + _IndexOffset;
             RawIndexData = reader.ReadBytes( ( int )( IndexCount * 2 + padding ) );


### PR DESCRIPTION
context discord thread: https://discord.com/channels/1081353100012568726/1370560059423330394

this PR preempts the ThrowForEmptyQueue exception when trying to populate loaded MDL data. the above thread links a .mdl file which completely fails to load on main branch, while on this branch it only kinda-fails. the mdl can be re-saved after loading and bind points edited to have a successful parse, but parts of the data still appear malformed and I've no clue how to fix it further than just ignoring the worst bits!

```
00:35:21.725 | INF | [VFXEditor] j_brush
00:35:21.725 | INF | [VFXEditor] n_hara
00:35:21.725 | INF | [VFXEditor] n_root
00:35:21.725 | INF | [VFXEditor] /mt_w2901b0026_a.mtrl
00:35:21.725 | ERR | [VFXEditor] Error Reading File
    System.InvalidOperationException: Queue empty.
       at System.Collections.Generic.Queue`1.ThrowForEmptyQueue()
       at System.Collections.Generic.Queue`1.Dequeue()
       at VfxEditor.Formats.MdlFormat.Mesh.Base.MdlMeshData.PopulateIndexData(MdlFileData data, BinaryReader reader, Int32 lod) in /work/repo/VFXEditor/Formats/MdlFormat/Mesh/Base/MdlMeshData.cs:line 31
       at VfxEditor.Formats.MdlFormat.Mesh.MdlMesh.Populate(MdlFileData data, BinaryReader reader, Int32 lod) in /work/repo/VFXEditor/Formats/MdlFormat/Mesh/MdlMesh.cs:line 102
       at VfxEditor.Formats.MdlFormat.Lod.MdlLod.Populate(MdlFileData data, BinaryReader reader, Int32 lod) in /work/repo/VFXEditor/Formats/MdlFormat/Lod/MdlLod.cs:line 150
       at VfxEditor.Formats.MdlFormat.MdlFile..ctor(BinaryReader reader, Boolean verify) in /work/repo/VFXEditor/Formats/MdlFormat/MdlFile.cs:line 233
       at VfxEditor.Formats.MdlFormat.MdlDocument.FileFromReader(BinaryReader reader, Boolean verify) in /work/repo/VFXEditor/Formats/MdlFormat/MdlDocument.cs:line 16
       at VfxEditor.FileManager.FileManagerDocument`2.LoadLocal(String path, Boolean verify) in /work/repo/VFXEditor/FileManager/FileManagerDocument.cs:line 71
```