### PR TITLE
proposed changes to TMFC-related code

### DIFF
--- a/VFXEditor/Formats/PapFormat/PapDocument.cs
+++ b/VFXEditor/Formats/PapFormat/PapDocument.cs
@@ -33,7 +33,7 @@ namespace VfxEditor.PapFormat {
 
         protected override void DrawBody() {
             ImGui.SetCursorPosY( ImGui.GetCursorPosY() + 5 );
-            DrawAnimationWarning();
+            //DrawAnimationWarning();
             base.DrawBody();
         }
     }

--- a/VFXEditor/Formats/TmbFormat/Entries/C013.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C013.cs
@@ -6,7 +6,7 @@ using VfxEditor.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C013 : TmbEntry {
         public const string MAGIC = "C013";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Model Animation";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
 
@@ -17,7 +17,7 @@ namespace VfxEditor.TmbFormat.Entries {
         private readonly ParsedInt Duration = new( "Duration" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
         private readonly ParsedInt TmfcId = new( "F-Curve Id" );
-        private readonly ParsedInt Unk4 = new( "Unknown 4" );
+        private readonly ParsedInt Placement = new( "Placement" );
 
         public C013( TmbFile file ) : base( file ) { }
 
@@ -27,7 +27,7 @@ namespace VfxEditor.TmbFormat.Entries {
             Duration,
             Unk2,
             TmfcId,
-            Unk4
+            Placement
         ];
     }
 }

--- a/VFXEditor/Formats/TmbFormat/Entries/C117.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C117.cs
@@ -6,7 +6,7 @@ using VfxEditor.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C117 : TmbEntry {
         public const string MAGIC = "C117";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Forced Forward Movement";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
         public override DangerLevel Danger => DangerLevel.Detectable;

--- a/VFXEditor/Formats/TmbFormat/Entries/C124.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C124.cs
@@ -6,7 +6,7 @@ using VfxEditor.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C124 : TmbEntry {
         public const string MAGIC = "C124";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Targetable";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
         public override DangerLevel Danger => DangerLevel.Red;
@@ -14,18 +14,18 @@ namespace VfxEditor.TmbFormat.Entries {
         public override int Size => 0x18;
         public override int ExtraSize => 0;
 
-        private readonly ParsedInt Unk1 = new( "Unknown 1", value: 1 );
+        private readonly ParsedBool Enabled = new( "Enabled" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
-        private readonly ParsedInt Unk3 = new( "Unknown 3", value: 100 );
+        private readonly ParsedBool Targetable = new( "Targetable" );
 
         public C124( TmbFile file ) : base( file ) { }
 
         public C124( TmbFile file, TmbReader reader ) : base( file, reader ) { }
 
         protected override List<ParsedBase> GetParsed() => [
-            Unk1,
+            Enabled,
             Unk2,
-            Unk3
+            Targetable
         ];
     }
 }

--- a/VFXEditor/Formats/TmbFormat/Entries/C139.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C139.cs
@@ -6,10 +6,10 @@ using VfxEditor.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C139 : TmbEntry {
         public const string MAGIC = "C139";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Forced Movement Cancel";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
-        public override DangerLevel Danger => DangerLevel.Yellow;
+        public override DangerLevel Danger => DangerLevel.Detectable;
 
         public override int Size => 0x14;
         public override int ExtraSize => 0;

--- a/VFXEditor/Formats/TmbFormat/Entries/C168.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C168.cs
@@ -6,10 +6,10 @@ using VfxEditor.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C168 : TmbEntry {
         public const string MAGIC = "C168";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Forced Camera Control";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
-        public override DangerLevel Danger => DangerLevel.Detectable;
+        public override DangerLevel Danger => DangerLevel.Yellow;
 
         public override int Size => 0x38;
         public override int ExtraSize => 0;
@@ -17,14 +17,16 @@ namespace VfxEditor.TmbFormat.Entries {
         private readonly ParsedInt Duration = new( "Duration" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
         private readonly ParsedInt TmfcId = new( "F-Curve Id" );
-        private readonly ParsedInt Unk4 = new( "Unknown 4" ); // <-----
-        private readonly ParsedInt Unk5 = new( "Unknown 5" );
-        private readonly ParsedInt Unk6 = new( "Unknown 6" );
+        private readonly ParsedByte Unk4 = new( "Unknown 4" ); // <-----
+        private readonly ParsedByte Unk5 = new( "Unknown 5" );
+        private readonly ParsedShort Unk6 = new( "Unknown 6" );
         private readonly ParsedInt Unk7 = new( "Unknown 7" );
         private readonly ParsedInt Unk8 = new( "Unknown 8" );
         private readonly ParsedInt Unk9 = new( "Unknown 9" );
         private readonly ParsedInt Unk10 = new( "Unknown 10" );
         private readonly ParsedInt Unk11 = new( "Unknown 11" );
+        private readonly ParsedInt Unk12 = new( "Unknown 12" );
+        private readonly ParsedInt Unk13 = new( "Unknown 13" );
 
         public C168( TmbFile file ) : base( file ) { }
 
@@ -41,7 +43,9 @@ namespace VfxEditor.TmbFormat.Entries {
             Unk8,
             Unk9,
             Unk10,
-            Unk11
+            Unk11,
+            Unk12,
+            Unk13
         ];
     }
 }

--- a/VFXEditor/Formats/TmbFormat/Entries/C176.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C176.cs
@@ -6,7 +6,7 @@ using VfxEditor.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C176 : TmbEntry {
         public const string MAGIC = "C176";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Forced Vertical Movement";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
         public override DangerLevel Danger => DangerLevel.Detectable;
@@ -17,10 +17,12 @@ namespace VfxEditor.TmbFormat.Entries {
         private readonly ParsedInt Duration = new( "Duration" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
         private readonly ParsedInt TmfcId = new( "F-Curve Id" );
-        private readonly ParsedInt Unk4 = new( "Unknown 4" );
-        private readonly ParsedInt Unk5 = new( "Unknown 5" );
-        private readonly ParsedInt Unk6 = new( "Unknown 6" );
+        private readonly ParsedByte Unk4 = new( "Unknown 4" );
+        private readonly ParsedByte Unk5 = new( "Unknown 5" );
+        private readonly ParsedShort Unk6 = new( "Unknown 6" );
         private readonly ParsedInt Unk7 = new( "Unknown 7" );
+        private readonly ParsedInt Unk8 = new( "Unknown 8" );
+        private readonly ParsedInt Unk9 = new( "Unknown 9" );
 
         public C176( TmbFile file ) : base( file ) { }
 
@@ -34,6 +36,8 @@ namespace VfxEditor.TmbFormat.Entries {
             Unk5,
             Unk6,
             Unk7,
+            Unk8,
+            Unk9
         ];
     }
 }

--- a/VFXEditor/Formats/TmbFormat/Entries/C177.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C177.cs
@@ -6,7 +6,7 @@ using VfxEditor.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C177 : TmbEntry {
         public const string MAGIC = "C177";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Forced Backwards Movement";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
         public override DangerLevel Danger => DangerLevel.Detectable;

--- a/VFXEditor/Formats/TmbFormat/Entries/C192.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C192.cs
@@ -6,7 +6,7 @@ using VfxEditor.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C192 : TmbEntry {
         public const string MAGIC = "C192";
-        public const string DISPLAY_NAME = "Voiceline";
+        public const string DISPLAY_NAME = "";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
         public override DangerLevel Danger => DangerLevel.Yellow;
@@ -16,7 +16,7 @@ namespace VfxEditor.TmbFormat.Entries {
 
         private readonly ParsedInt Unk1 = new( "Unknown 1" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
-        private readonly ParsedInt VoicelineNumber = new( "Voiceline Number" );
+        private readonly ParsedInt Unk3 = new( "Unknown 3" ); //not voiceline, but similar format
         private readonly ParsedInt Unk4 = new( "Unknown 4" );
         private readonly ParsedInt Unk5 = new( "Unknown 5" );
         private readonly ParsedInt Unk6 = new( "Unknown 6" );
@@ -33,7 +33,7 @@ namespace VfxEditor.TmbFormat.Entries {
         protected override List<ParsedBase> GetParsed() => [
             Unk1,
             Unk2,
-            VoicelineNumber,
+            Unk3,
             Unk4,
             Unk5,
             Unk6,

--- a/VFXEditor/Formats/TmbFormat/Tmfcs/TmfcRow.cs
+++ b/VFXEditor/Formats/TmbFormat/Tmfcs/TmfcRow.cs
@@ -5,8 +5,8 @@ namespace VfxEditor.TmbFormat.Tmfcs {
     public class TmfcRow {
         public readonly ParsedUInt Unk1 = new( "Unknown 1" );
         public readonly ParsedFloat Time = new( "Time" );
-        public readonly ParsedFloat Unk2 = new( "Unknown 2" );
-        public readonly ParsedFloat Unk3 = new( "Unknown 3" );
+        public readonly ParsedFloat Unk2 = new( "Velocity" );
+        public readonly ParsedFloat Unk3 = new( "Distance %" );
         public readonly ParsedFloat Unk4 = new( "Unknown 4" );
         public readonly ParsedFloat Unk5 = new( "Unknown 5" );
 

--- a/VFXEditor/Select/Tabs/Actions/ActionTabPap.cs
+++ b/VFXEditor/Select/Tabs/Actions/ActionTabPap.cs
@@ -12,7 +12,7 @@ namespace VfxEditor.Select.Tabs.Actions {
 
         public override void LoadData() {
             var sheet = Dalamud.DataManager.GetExcelSheet<Action>()
-                .Where( x => !string.IsNullOrEmpty( x.Name.ExtractText() ) && ( x.IsPlayerAction || x.ClassJob.ValueNullable != null ) && !x.AffectsPosition );
+                .Where( x => !string.IsNullOrEmpty( x.Name.ExtractText() ) && ( x.IsPlayerAction || x.ClassJob.ValueNullable != null ) ); //&& !x.AffectsPosition );
             foreach( var item in sheet ) Items.Add( new ActionRowPap( item ) );
         }
 

--- a/VFXEditor/Select/Tabs/Actions/ActionTabPapNonPlayer.cs
+++ b/VFXEditor/Select/Tabs/Actions/ActionTabPapNonPlayer.cs
@@ -7,7 +7,7 @@ namespace VfxEditor.Select.Tabs.Actions {
 
         public override void LoadData() {
             var sheet = Dalamud.DataManager.GetExcelSheet<Action>()
-                .Where( x => !string.IsNullOrEmpty( x.Name.ExtractText() ) && !( x.IsPlayerAction || x.ClassJob.ValueNullable != null ) && !x.AffectsPosition );
+                .Where( x => !string.IsNullOrEmpty( x.Name.ExtractText() ) && !( x.IsPlayerAction || x.ClassJob.ValueNullable != null ) ); //&& !x.AffectsPosition );
             foreach( var item in sheet ) Items.Add( new( item ) );
         }
     }


### PR DESCRIPTION
feel free to reject the pull if you need to, or take only what you think would be least intrusive

included are potential changes to improve surface-level transparency on what some of the danger codes do (and bandage up a couple danger-code fields to be bytes/shorts instead of just ints)

additionally, there's no need to hide movement PAPs, since TMFCs don't exist for the file type. this can be reverted in the eventuality it's used. following that, I chose to comment out the warning for the PAP window. however, the TMB side is preserved in both of these regards