### PR TITLE
tmb changes

### DIFF
--- a/VFXEditor/Formats/TmbFormat/Entries/C012.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C012.cs
@@ -6,10 +6,10 @@ using VfxEditor.TmbFormat.Utils;
 
 namespace VfxEditor.TmbFormat.Entries {
     public enum VfxVisibility {
-        Unknown_0 = 0,
-        Unknown_1 = 1,
-        Everyone = 2,
-        Unknown_3 = 3,
+        Default_no_Triggers = 0,
+        Default_with_Triggers = 1,
+        Always_no_Triggers = 2,
+        Always_with_Triggers = 3,
     }
 
     public class C012 : TmbEntry {

--- a/VFXEditor/Formats/TmbFormat/Entries/C015.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C015.cs
@@ -3,6 +3,14 @@ using VfxEditor.Parsing;
 using VfxEditor.TmbFormat.Utils;
 
 namespace VfxEditor.TmbFormat.Entries {
+    public enum AtchState {
+        State_1 = 0,
+        State_0 = 1,
+        State_2 = 2,
+        State_3 = 3,
+        State_4 = 4,
+        State_5 = 5,
+    }
     public class C015 : TmbEntry {
         public const string MAGIC = "C015";
         public const string DISPLAY_NAME = "Weapon Size";
@@ -12,9 +20,9 @@ namespace VfxEditor.TmbFormat.Entries {
         public override int Size => 0x1C;
         public override int ExtraSize => 0;
 
-        private readonly ParsedInt Unk1 = new( "Unknown 1" );
+        private readonly ParsedInt Duration = new( "Duration" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
-        private readonly ParsedInt WeaponSize = new( "Size" );
+        private readonly ParsedEnum<AtchState> WeaponSize = new( "ATCH Object Scale" );
         private readonly ParsedEnum<ObjectControl> ObjectControl = new( "Object Control" );
 
         public C015( TmbFile file ) : base( file ) { }
@@ -22,7 +30,7 @@ namespace VfxEditor.TmbFormat.Entries {
         public C015( TmbFile file, TmbReader reader ) : base( file, reader ) { }
 
         protected override List<ParsedBase> GetParsed() => [
-            Unk1,
+            Duration,
             Unk2,
             WeaponSize,
             ObjectControl

--- a/VFXEditor/Formats/TmbFormat/Entries/C063.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C063.cs
@@ -13,7 +13,7 @@ namespace VfxEditor.TmbFormat.Entries {
         public override int Size => 0x20;
         public override int ExtraSize => 0;
 
-        private readonly ParsedInt Loop = new( "Loop", value: 1 );
+        private readonly ParsedInt Loop = new( "Loop/Duration", value: 1 );
         private readonly ParsedInt Interrupt = new( "Interrupt" );
         private readonly TmbOffsetString Path = new( "Path", null, true );
         private readonly ParsedInt SoundIndex = new( "Sound Index" );

--- a/VFXEditor/Formats/TmbFormat/Entries/C107.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C107.cs
@@ -5,16 +5,16 @@ using VfxEditor.TmbFormat.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C107 : TmbEntry {
         public const string MAGIC = "C107";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "VFX Trigger";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
 
         public override int Size => 0x1C;
         public override int ExtraSize => 0;
 
-        private readonly ParsedInt Unk1 = new( "Unknown 1" );
+        private readonly ParsedInt Enabled = new( "Enabled" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
-        private readonly ParsedInt Unk3 = new( "Unknown 3" );
+        private readonly ParsedInt TriggerRow = new( "Row" ); //row + 1
         private readonly ParsedInt Unk4 = new( "Unknown 4" );
 
         public C107( TmbFile file ) : base( file ) { }
@@ -22,9 +22,9 @@ namespace VfxEditor.TmbFormat.Entries {
         public C107( TmbFile file, TmbReader reader ) : base( file, reader ) { }
 
         protected override List<ParsedBase> GetParsed() => [
-            Unk1,
+            Enabled,
             Unk2,
-            Unk3,
+            TriggerRow,
             Unk4
         ];
     }

--- a/VFXEditor/Formats/TmbFormat/Entries/C142.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C142.cs
@@ -4,8 +4,8 @@ using VfxEditor.TmbFormat.Utils;
 
 namespace VfxEditor.TmbFormat.Entries {
     public enum FreezePositionType {
-        Target_0,
-        Target_1,
+        Target_FixedDirection,
+        Target_UserFacingDirection,
         Return
     }
 
@@ -20,7 +20,7 @@ namespace VfxEditor.TmbFormat.Entries {
 
         private readonly ParsedInt Duration = new( "Duration" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
-        private readonly ParsedInt Position = new( "Position" );
+        private readonly ParsedInt Position = new( "Bind Point" );
         private readonly ParsedEnum<FreezePositionType> FreezeLocation = new( "Freeze Location" );
 
         public C142( TmbFile file ) : base( file ) { }

--- a/VFXEditor/Formats/TmbFormat/Entries/C143.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C143.cs
@@ -14,7 +14,7 @@ namespace VfxEditor.TmbFormat.Entries {
 
         private readonly ParsedBool Enabled = new( "Enabled" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
-        private readonly ParsedInt Unk3 = new( "Unknown 3" );
+        private readonly ParsedInt BankId = new( "Bank Id" );
 
         public C143( TmbFile file ) : base( file ) { }
 
@@ -23,7 +23,7 @@ namespace VfxEditor.TmbFormat.Entries {
         protected override List<ParsedBase> GetParsed() => [
             Enabled,
             Unk2,
-            Unk3
+            BankId
         ];
     }
 }

--- a/VFXEditor/Formats/TmbFormat/Entries/C161.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C161.cs
@@ -5,16 +5,16 @@ using VfxEditor.TmbFormat.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C161 : TmbEntry {
         public const string MAGIC = "C161";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Blink";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
 
         public override int Size => 0x1C;
         public override int ExtraSize => 0;
 
-        private readonly ParsedInt Unk1 = new( "Unknown 1" );
+        private readonly ParsedInt Enabled = new( "Enabled" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
-        private readonly ParsedInt Unk3 = new( "Unknown 3" );
+        private readonly ParsedBool Blink = new( "Blink" );
         private readonly ParsedInt Unk4 = new( "Unknown 4" );
 
         public C161( TmbFile file ) : base( file ) { }
@@ -22,9 +22,9 @@ namespace VfxEditor.TmbFormat.Entries {
         public C161( TmbFile file, TmbReader reader ) : base( file, reader ) { }
 
         protected override List<ParsedBase> GetParsed() => [
-            Unk1,
+            Enabled,
             Unk2,
-            Unk3,
+            Blink,
             Unk4
         ];
     }

--- a/VFXEditor/Formats/TmbFormat/Entries/C173.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C173.cs
@@ -14,7 +14,7 @@ namespace VfxEditor.TmbFormat.Entries {
         public override int Size => 0x44;
         public override int ExtraSize => 0;
 
-        private readonly ParsedInt Unk1 = new( "Unknown 1", value: 1 );
+        private readonly ParsedInt Loop = new( "Loop / Wait", value: 1 );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
         private readonly TmbOffsetString Path = new( "Path", [
             new() {
@@ -28,8 +28,8 @@ namespace VfxEditor.TmbFormat.Entries {
         ], false );
         private readonly ParsedShort BindPoint1 = new( "Bind Point 1", value: 1 );
         private readonly ParsedShort BindPoint2 = new( "Bind Point 2", value: 0xFF );
-        private readonly ParsedInt Unk3 = new( "Unknown 3" );
-        private readonly ParsedInt Unk4 = new( "Unknown 4" );
+        private readonly ParsedInt Visibility = new( "Visibility" ); //doesn't seem to use the same enum
+        private readonly ParsedInt Limit = new( "Limit" );
         private readonly ParsedInt Unk5 = new( "Unknown 5" );
         private readonly ParsedInt Unk6 = new( "Unknown 6" );
         private readonly ParsedInt Unk7 = new( "Unknown 7" );
@@ -44,13 +44,13 @@ namespace VfxEditor.TmbFormat.Entries {
         public C173( TmbFile file, TmbReader reader ) : base( file, reader ) { }
 
         protected override List<ParsedBase> GetParsed() => [
-            Unk1,
+            Loop,
             Unk2,
             Path,
             BindPoint1,
             BindPoint2,
-            Unk3,
-            Unk4,
+            Visibility,
+            Limit,
             Unk5,
             Unk6,
             Unk7,

--- a/VFXEditor/Formats/TmbFormat/Entries/C174.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C174.cs
@@ -4,21 +4,21 @@ using VfxEditor.TmbFormat.Utils;
 
 namespace VfxEditor.TmbFormat.Entries {
     public enum ObjectControlPosition {
-        Stowed = 0,
-        RightHand = 1,
-        Unknown = 2,
-        SwitchHand = 3,
-        RootBone = 4,
-        SwitchReverse = 5
+        Stowed_State1 = 0,
+        Drawn_State0 = 1,
+        CraftGather_State2 = 2,
+        SwitchHand_State3 = 3,
+        n_throw_State4 = 4,
+        SwitchReverse_State5 = 5
     }
 
     public enum ObjectControlFinal {
-        Stowed = 0,
-        Drawn = 1,
-        Weapon = 2,
-        OffHand = 3,
-        RootBone = 4,
-        UncontrolledRoot = 5,
+        Stowed_State1 = 0,
+        Drawn_State0 = 1,
+        CraftGather_State2 = 2,
+        SwitchHand_State3 = 3,
+        n_throw_State4 = 4,
+        SwitchReverse_State5 = 5,
         Original = 6,
     }
 

--- a/VFXEditor/Formats/TmbFormat/Entries/C175.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C175.cs
@@ -14,10 +14,10 @@ namespace VfxEditor.TmbFormat.Entries {
 
         private readonly ParsedInt Duration = new( "Duration" );
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
-        private readonly ParsedInt Unk3 = new( "Unknown 3", value: 4 );
+        private readonly ParsedEnum<ObjectControlPosition> ObjectScale = new( "Object Scale" );
         private readonly ParsedEnum<ObjectControl> ObjectControl = new( "Object Control" );
-        private readonly ParsedInt Unk5 = new( "Unknown 5", value: 1 );
-        private readonly ParsedInt Unk6 = new( "Unknown 6", value: 1 );
+        private readonly ParsedEnum<ObjectControlFinal> FinalScale = new( "Final Scale" );
+        private readonly ParsedInt ScaleDelay = new( "Scale Delay", value: 1 );
         private readonly ParsedInt Unk7 = new( "Unknown 7" );
 
         public C175( TmbFile file ) : base( file ) { }
@@ -27,10 +27,10 @@ namespace VfxEditor.TmbFormat.Entries {
         protected override List<ParsedBase> GetParsed() => [
             Duration,
             Unk2,
-            Unk3,
+            ObjectScale,
             ObjectControl,
-            Unk5,
-            Unk6,
+            FinalScale,
+            ScaleDelay,
             Unk7
         ];
 

--- a/VFXEditor/Formats/TmbFormat/Entries/C197.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C197.cs
@@ -4,6 +4,12 @@ using VfxEditor.TmbFormat.Utils;
 
 namespace VfxEditor.TmbFormat.Entries {
     public class C197 : TmbEntry {
+        public enum SpeakTmbType {
+            Normal = 0,
+            Whisper = 1,
+            Shout = 2,
+            Disabled = 3,
+        }
         public const string MAGIC = "C197";
         public const string DISPLAY_NAME = "Voiceline";
         public override string DisplayName => DISPLAY_NAME;
@@ -16,7 +22,7 @@ namespace VfxEditor.TmbFormat.Entries {
         private readonly ParsedInt Unk2 = new( "Unknown 2" );
         private readonly ParsedInt VoicelineNumber = new( "Voiceline Number" );
         private readonly ParsedInt BindPointId = new( "Bind Point Id" );
-        private readonly ParsedInt Unk5 = new( "Unknown 5" );
+        private readonly ParsedEnum<SpeakTmbType> SpeakType = new( "Speak Type" ); // chara/action/speak/*.tmb
         private readonly ParsedInt Unk6 = new( "Unknown 6" );
 
         public C197( TmbFile file ) : base( file ) { }
@@ -28,7 +34,7 @@ namespace VfxEditor.TmbFormat.Entries {
             Unk2,
             VoicelineNumber,
             BindPointId,
-            Unk5,
+            SpeakType,
             Unk6
         ];
     }

--- a/VFXEditor/Formats/TmbFormat/Entries/C203.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C203.cs
@@ -6,7 +6,7 @@ namespace VfxEditor.TmbFormat.Entries {
     public enum SummonWeaponObjectControl {
         Weapon = 0,
         OffHand = 1,
-        Unknown_2 = 2,
+        Summon_or_Lemure = 2,
     }
 
     public class C203 : TmbEntry {
@@ -23,7 +23,7 @@ namespace VfxEditor.TmbFormat.Entries {
         private readonly ParsedInt BindPointId = new( "Bind Point Id" );
         private readonly ParsedInt Rotation = new( "Rotation" );
         private readonly ParsedEnum<SummonWeaponObjectControl> ObjectControl = new( "Object Control" );
-        private readonly ParsedBool NoulithAlignment = new( "Noulith Alignment" );
+        private readonly ParsedBool NoFollow = new( "Disable Follow" );
         private readonly ParsedBool ScaleEnabled = new( "Scale Enabled", size: 2 );
         private readonly ParsedShort Unk3 = new( "Unknown 3" );
         private readonly ParsedFloat Scale = new( "Scale" );
@@ -38,7 +38,7 @@ namespace VfxEditor.TmbFormat.Entries {
             BindPointId,
             Rotation,
             ObjectControl,
-            NoulithAlignment,
+            NoFollow,
             ScaleEnabled,
             Unk3,
             Scale

--- a/VFXEditor/Formats/TmbFormat/Entries/C204.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C204.cs
@@ -5,7 +5,7 @@ using VfxEditor.TmbFormat.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C204 : TmbEntry {
         public const string MAGIC = "C204";
-        public const string DISPLAY_NAME = "Reaper Shroud";
+        public const string DISPLAY_NAME = "Shroud Transform"; //applies to both RPR and SCH
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
 

--- a/VFXEditor/Formats/TmbFormat/Entries/C216.cs
+++ b/VFXEditor/Formats/TmbFormat/Entries/C216.cs
@@ -5,19 +5,19 @@ using VfxEditor.TmbFormat.Utils;
 namespace VfxEditor.TmbFormat.Entries {
     public class C216 : TmbEntry {
         public const string MAGIC = "C216";
-        public const string DISPLAY_NAME = "";
+        public const string DISPLAY_NAME = "Subtitles";
         public override string DisplayName => DISPLAY_NAME;
         public override string Magic => MAGIC;
 
         public override int Size => 0x30;
         public override int ExtraSize => 0;
 
-        public readonly ParsedInt Unknown1 = new( "Unknown 1" );
+        public readonly ParsedBool Enabled = new( "Enabled" );
         public readonly ParsedInt Unknown2 = new( "Unknown 2" );
-        public readonly ParsedInt Unknown3 = new( "Unknown 3" );
-        public readonly ParsedInt Unknown4 = new( "Unknown 4" );
-        public readonly ParsedInt Unknown5 = new( "Unknown 5" );
-        public readonly ParsedFloat Unknown6 = new( "Unknown 6" );
+        public readonly ParsedInt SubtitleType = new( "Subtitle Type" );
+        public readonly ParsedInt TextId = new( "Text Id" );
+        public readonly ParsedInt SpeakerId = new( "Speaker Id" );
+        public readonly ParsedFloat Duration = new( "Duration" );
         public readonly ParsedInt Unknown7 = new( "Unknown 7" );
         public readonly ParsedInt Unknown8 = new( "Unknown 8" );
         public readonly ParsedInt Unknown9 = new( "Unknown 9" );
@@ -27,12 +27,12 @@ namespace VfxEditor.TmbFormat.Entries {
         public C216( TmbFile file, TmbReader reader ) : base( file, reader ) { }
 
         protected override List<ParsedBase> GetParsed() => [
-            Unknown1,
+            Enabled,
             Unknown2,
-            Unknown3,
-            Unknown4,
-            Unknown5,
-            Unknown6,
+            SubtitleType,
+            TextId,
+            SpeakerId,
+            Duration,
             Unknown7,
             Unknown8,
             Unknown9


### PR DESCRIPTION
last of batch changes from me

unsure on the enumerable and variable naming for object control codes, since it's not always clear cut what bone the ATCH state uses (like on left-handed jobs, where `SwitchHand` will use the same bone as `Weapon`), so for now I just chose to append its state number on the enum because idk