### PR TITLE
Bunch of fixes for parsing errors, crashes, and some general fixes/improvements.

### DIFF
--- a/VFXEditor/DirectX/Model/ModelPreview.cs
+++ b/VFXEditor/DirectX/Model/ModelPreview.cs
@@ -62,8 +62,7 @@ namespace VfxEditor.DirectX {
         public void LoadModel( AvfxModel model, RenderMode mode ) => LoadModel( model.Indexes.Indexes, model.Vertexes.Vertexes, model.AllEmitVertexes, mode );
 
         public void LoadModel( List<AvfxIndex> modelIndexes, List<AvfxVertex> modelVertexes, List<UiEmitVertex> modelEmitters, RenderMode mode ) {
-            if( modelIndexes.Count == 0 )
-            {
+            if( modelIndexes.Count == 0 ) {
                 Model.ClearVertexes();
             }
             else {
@@ -116,8 +115,7 @@ namespace VfxEditor.DirectX {
             if( normal.Equals( originalNormal ) ) return Quaternion.Identity;
 
             var rotationAxis = Vector3.Cross( normal, originalNormal );
-            if( rotationAxis.Length() == 0f )
-            { // N = -N'
+            if( rotationAxis.Length() == 0f ) { // N = -N'
                 return Quaternion.RotationAxis( Vector3.UnitX, ( float )Math.PI );
             }
 
@@ -128,8 +126,7 @@ namespace VfxEditor.DirectX {
 
         protected override void DrawPasses() {
             Model.Draw( Ctx, PassType.Final, VertexShaderBuffer, PixelShaderBuffer );
-            if( Plugin.Configuration.ModelShowEmitters )
-            {
+            if( Plugin.Configuration.ModelShowEmitters ) {
                 Emitters.Draw( Ctx, PassType.Final, VertexShaderBuffer, PixelShaderBuffer );
             }
         }

--- a/VFXEditor/DirectX/Model/ModelPreview.cs
+++ b/VFXEditor/DirectX/Model/ModelPreview.cs
@@ -10,9 +10,12 @@ using VfxEditor.DirectX.Drawable;
 using VfxEditor.DirectX.Renderers;
 using Device = SharpDX.Direct3D11.Device;
 
-namespace VfxEditor.DirectX {
-    public class ModelPreview : ModelRenderer {
-        public enum RenderMode {
+namespace VfxEditor.DirectX
+{
+    public class ModelPreview : ModelRenderer
+    {
+        public enum RenderMode
+        {
             Color,
             Uv1,
             Uv2,
@@ -24,7 +27,8 @@ namespace VfxEditor.DirectX {
         private readonly D3dDrawable Model;
         private readonly D3dDrawable Emitters;
 
-        public ModelPreview( Device device, DeviceContext ctx, string shaderPath ) : base( device, ctx, shaderPath ) {
+        public ModelPreview( Device device, DeviceContext ctx, string shaderPath ) : base( device, ctx, shaderPath )
+        {
             Model = new( 3, false,
                 [
                     new( "POSITION", 0, Format.R32G32B32A32_Float, 0, 0 ),
@@ -47,7 +51,8 @@ namespace VfxEditor.DirectX {
             UpdatePyramidMesh();
         }
 
-        public void UpdatePyramidMesh() {
+        public void UpdatePyramidMesh()
+        {
             var builder = new MeshBuilder( true, false );
             builder.AddPyramid(
                 new Vector3( 0, 0, 0 ),
@@ -59,23 +64,29 @@ namespace VfxEditor.DirectX {
             Emitters.SetVertexes( Device, data, emitterCount );
         }
 
-        public void LoadModel( AvfxModel model, RenderMode mode ) => LoadModel( model.Indexes.Indexes, model.Vertexes.Vertexes, model.CombinedEmitVertexes, mode );
+        public void LoadModel( AvfxModel model, RenderMode mode ) => LoadModel( model.Indexes.Indexes, model.Vertexes.Vertexes, model.AllEmitVertexes, mode );
 
-        public void LoadModel( List<AvfxIndex> modelIndexes, List<AvfxVertex> modelVertexes, List<UiEmitVertex> modelEmitters, RenderMode mode ) {
-            if( modelIndexes.Count == 0 ) {
+        public void LoadModel( List<AvfxIndex> modelIndexes, List<AvfxVertex> modelVertexes, List<UiEmitVertex> modelEmitters, RenderMode mode )
+        {
+            if( modelIndexes.Count == 0 )
+            {
                 Model.ClearVertexes();
             }
-            else {
+            else
+            {
                 var data = new List<Vector4>();
 
-                for( var index = 0; index < modelIndexes.Count; index++ ) { // each face
+                for( var index = 0; index < modelIndexes.Count; index++ )
+                { // each face
                     var indexes = new int[] { modelIndexes[index].I1, modelIndexes[index].I2, modelIndexes[index].I3 };
-                    for( var j = 0; j < indexes.Length; j++ ) { // push all 3 vertices per face
+                    for( var j = 0; j < indexes.Length; j++ )
+                    { // push all 3 vertices per face
                         var vertex = modelVertexes[indexes[j]];
                         var normal = new Vector3( vertex.Normal[0], vertex.Normal[1], vertex.Normal[2] );
 
                         data.Add( new Vector4( vertex.Position[0], vertex.Position[1], vertex.Position[2], 1.0f ) );
-                        data.Add( mode switch {
+                        data.Add( mode switch
+                        {
                             RenderMode.Color => new Vector4( new Vector3( vertex.Color[0], vertex.Color[1], vertex.Color[2] ) / 255, 1.0f ),
                             RenderMode.Uv1 => new Vector4( vertex.Uv1.X + 0.5f, 0, vertex.Uv1.Y + 0.5f, 1.0f ),
                             RenderMode.Uv2 => new Vector4( vertex.Uv2.X + 0.5f, 0, vertex.Uv2.Y + 0.5f, 1.0f ),
@@ -93,12 +104,15 @@ namespace VfxEditor.DirectX {
 
             // ========= EMITTERS =====
 
-            if( modelEmitters.Count == 0 ) {
+            if( modelEmitters.Count == 0 )
+            {
                 Emitters.ClearInstances();
             }
-            else {
+            else
+            {
                 var data = new List<Matrix>();
-                for( var idx = 0; idx < modelEmitters.Count; idx++ ) {
+                for( var idx = 0; idx < modelEmitters.Count; idx++ )
+                {
                     var emitter = modelEmitters[idx];
                     var pos = new Vector3( emitter.Position.X, emitter.Position.Y, emitter.Position.Z );
                     var rot = GetEmitterRotationQuat( new Vector3( emitter.Normal.X, emitter.Normal.Y, emitter.Normal.Z ) );
@@ -110,12 +124,14 @@ namespace VfxEditor.DirectX {
             UpdateDraw();
         }
 
-        private static Quaternion GetEmitterRotationQuat( Vector3 normal ) {
+        private static Quaternion GetEmitterRotationQuat( Vector3 normal )
+        {
             var originalNormal = Vector3.UnitY;
             if( normal.Equals( originalNormal ) ) return Quaternion.Identity;
 
             var rotationAxis = Vector3.Cross( normal, originalNormal );
-            if( rotationAxis.Length() == 0f ) { // N = -N'
+            if( rotationAxis.Length() == 0f )
+            { // N = -N'
                 return Quaternion.RotationAxis( Vector3.UnitX, ( float )Math.PI );
             }
 
@@ -124,16 +140,19 @@ namespace VfxEditor.DirectX {
             return Quaternion.RotationAxis( rotationAxis, ( float )rotationAngle );
         }
 
-        protected override void DrawPasses() {
+        protected override void DrawPasses()
+        {
             Model.Draw( Ctx, PassType.Final, VertexShaderBuffer, PixelShaderBuffer );
-            if( Plugin.Configuration.ModelShowEmitters ) {
+            if( Plugin.Configuration.ModelShowEmitters )
+            {
                 Emitters.Draw( Ctx, PassType.Final, VertexShaderBuffer, PixelShaderBuffer );
             }
         }
 
         protected override void DrawPopup() => Plugin.Configuration.DrawDirectXVfx();
 
-        public override void Dispose() {
+        public override void Dispose()
+        {
             base.Dispose();
             Model?.Dispose();
             Emitters?.Dispose();

--- a/VFXEditor/DirectX/Model/ModelPreview.cs
+++ b/VFXEditor/DirectX/Model/ModelPreview.cs
@@ -10,12 +10,9 @@ using VfxEditor.DirectX.Drawable;
 using VfxEditor.DirectX.Renderers;
 using Device = SharpDX.Direct3D11.Device;
 
-namespace VfxEditor.DirectX
-{
-    public class ModelPreview : ModelRenderer
-    {
-        public enum RenderMode
-        {
+namespace VfxEditor.DirectX {
+    public class ModelPreview : ModelRenderer {
+        public enum RenderMode {
             Color,
             Uv1,
             Uv2,
@@ -27,8 +24,7 @@ namespace VfxEditor.DirectX
         private readonly D3dDrawable Model;
         private readonly D3dDrawable Emitters;
 
-        public ModelPreview( Device device, DeviceContext ctx, string shaderPath ) : base( device, ctx, shaderPath )
-        {
+        public ModelPreview( Device device, DeviceContext ctx, string shaderPath ) : base( device, ctx, shaderPath ) {
             Model = new( 3, false,
                 [
                     new( "POSITION", 0, Format.R32G32B32A32_Float, 0, 0 ),
@@ -51,8 +47,7 @@ namespace VfxEditor.DirectX
             UpdatePyramidMesh();
         }
 
-        public void UpdatePyramidMesh()
-        {
+        public void UpdatePyramidMesh() {
             var builder = new MeshBuilder( true, false );
             builder.AddPyramid(
                 new Vector3( 0, 0, 0 ),
@@ -66,27 +61,22 @@ namespace VfxEditor.DirectX
 
         public void LoadModel( AvfxModel model, RenderMode mode ) => LoadModel( model.Indexes.Indexes, model.Vertexes.Vertexes, model.AllEmitVertexes, mode );
 
-        public void LoadModel( List<AvfxIndex> modelIndexes, List<AvfxVertex> modelVertexes, List<UiEmitVertex> modelEmitters, RenderMode mode )
-        {
+        public void LoadModel( List<AvfxIndex> modelIndexes, List<AvfxVertex> modelVertexes, List<UiEmitVertex> modelEmitters, RenderMode mode ) {
             if( modelIndexes.Count == 0 )
             {
                 Model.ClearVertexes();
             }
-            else
-            {
+            else {
                 var data = new List<Vector4>();
 
-                for( var index = 0; index < modelIndexes.Count; index++ )
-                { // each face
+                for( var index = 0; index < modelIndexes.Count; index++ ) { // each face
                     var indexes = new int[] { modelIndexes[index].I1, modelIndexes[index].I2, modelIndexes[index].I3 };
-                    for( var j = 0; j < indexes.Length; j++ )
-                    { // push all 3 vertices per face
+                    for( var j = 0; j < indexes.Length; j++ ) { // push all 3 vertices per face
                         var vertex = modelVertexes[indexes[j]];
                         var normal = new Vector3( vertex.Normal[0], vertex.Normal[1], vertex.Normal[2] );
 
                         data.Add( new Vector4( vertex.Position[0], vertex.Position[1], vertex.Position[2], 1.0f ) );
-                        data.Add( mode switch
-                        {
+                        data.Add( mode switch {
                             RenderMode.Color => new Vector4( new Vector3( vertex.Color[0], vertex.Color[1], vertex.Color[2] ) / 255, 1.0f ),
                             RenderMode.Uv1 => new Vector4( vertex.Uv1.X + 0.5f, 0, vertex.Uv1.Y + 0.5f, 1.0f ),
                             RenderMode.Uv2 => new Vector4( vertex.Uv2.X + 0.5f, 0, vertex.Uv2.Y + 0.5f, 1.0f ),
@@ -104,15 +94,12 @@ namespace VfxEditor.DirectX
 
             // ========= EMITTERS =====
 
-            if( modelEmitters.Count == 0 )
-            {
+            if( modelEmitters.Count == 0 ) {
                 Emitters.ClearInstances();
             }
-            else
-            {
+            else {
                 var data = new List<Matrix>();
-                for( var idx = 0; idx < modelEmitters.Count; idx++ )
-                {
+                for( var idx = 0; idx < modelEmitters.Count; idx++ ) {
                     var emitter = modelEmitters[idx];
                     var pos = new Vector3( emitter.Position.X, emitter.Position.Y, emitter.Position.Z );
                     var rot = GetEmitterRotationQuat( new Vector3( emitter.Normal.X, emitter.Normal.Y, emitter.Normal.Z ) );
@@ -124,8 +111,7 @@ namespace VfxEditor.DirectX
             UpdateDraw();
         }
 
-        private static Quaternion GetEmitterRotationQuat( Vector3 normal )
-        {
+        private static Quaternion GetEmitterRotationQuat( Vector3 normal ) {
             var originalNormal = Vector3.UnitY;
             if( normal.Equals( originalNormal ) ) return Quaternion.Identity;
 
@@ -140,8 +126,7 @@ namespace VfxEditor.DirectX
             return Quaternion.RotationAxis( rotationAxis, ( float )rotationAngle );
         }
 
-        protected override void DrawPasses()
-        {
+        protected override void DrawPasses() {
             Model.Draw( Ctx, PassType.Final, VertexShaderBuffer, PixelShaderBuffer );
             if( Plugin.Configuration.ModelShowEmitters )
             {
@@ -151,8 +136,7 @@ namespace VfxEditor.DirectX
 
         protected override void DrawPopup() => Plugin.Configuration.DrawDirectXVfx();
 
-        public override void Dispose()
-        {
+        public override void Dispose() {
             base.Dispose();
             Model?.Dispose();
             Emitters?.Dispose();

--- a/VFXEditor/FileManager/FileManagerDocument.cs
+++ b/VFXEditor/FileManager/FileManagerDocument.cs
@@ -95,8 +95,8 @@ namespace VfxEditor.FileManager {
                 File = FileFromReader( reader, verify );
             }
             catch( Exception e ) {
-                Dalamud.Error( e, "Error Reading File" );
-                Dalamud.ErrorNotification( "Error reading file" );
+                Dalamud.Error( e, "Error Reading File: " + path );
+                Dalamud.ErrorNotification( "Error reading file: " + path );
             }
         }
 

--- a/VFXEditor/Formats/AvfxFormat/Emitter/AvfxEmitterItem.cs
+++ b/VFXEditor/Formats/AvfxFormat/Emitter/AvfxEmitterItem.cs
@@ -1,7 +1,6 @@
 using Dalamud.Interface.Utility.Raii;
 using ImGuiNET;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using VfxEditor.Ui.Interfaces;
 using static VfxEditor.AvfxFormat.Enums;

--- a/VFXEditor/Formats/AvfxFormat/Emitter/AvfxEmitterItem.cs
+++ b/VFXEditor/Formats/AvfxFormat/Emitter/AvfxEmitterItem.cs
@@ -1,6 +1,7 @@
 using Dalamud.Interface.Utility.Raii;
 using ImGuiNET;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using VfxEditor.Ui.Interfaces;
 using static VfxEditor.AvfxFormat.Enums;
@@ -115,7 +116,7 @@ namespace VfxEditor.AvfxFormat {
             ];
         }
 
-        public AvfxEmitterItem( bool isParticle, AvfxEmitter emitter, bool initNodeSelects, BinaryReader reader ) : this( isParticle, emitter, initNodeSelects ) => AvfxBase.ReadNested( reader, Parsed, 312 );
+        public AvfxEmitterItem( bool isParticle, AvfxEmitter emitter, bool initNodeSelects, int size, BinaryReader reader ) : this( isParticle, emitter, initNodeSelects ) => AvfxBase.ReadNested( reader, Parsed, size );
 
         public void InitializeNodeSelects() {
             if( IsParticle ) ParticleSelect = new AvfxNodeSelect<AvfxParticle>( Emitter, "Target Particle", Emitter.NodeGroups.Particles, TargetIdx );

--- a/VFXEditor/Formats/AvfxFormat/Emitter/AvfxEmitterItemContainer.cs
+++ b/VFXEditor/Formats/AvfxFormat/Emitter/AvfxEmitterItemContainer.cs
@@ -14,7 +14,25 @@ namespace VfxEditor.AvfxFormat {
         }
 
         public override void ReadContents( BinaryReader reader, int size ) {
-            for( var i = 0; i < size / 312; i++ ) Items.Add( new AvfxEmitterItem( IsParticle, Emitter, false, reader ) );
+            if( ( float )size / 312 == size / 312 ){
+                for( var i = 0; i < size / 312; i++ ) Items.Add( new AvfxEmitterItem( IsParticle, Emitter, false, 312, reader ) );
+            }
+            else if( ( float )size / 300 == size / 300 )
+            {
+                for( var i = 0; i < size / 300; i++ ) Items.Add( new AvfxEmitterItem( IsParticle, Emitter, false, 300, reader ) );
+            }
+            else if( ( float )size / 288 == size / 288 )
+            {
+                for( var i = 0; i < size / 288; i++ ) Items.Add( new AvfxEmitterItem( IsParticle, Emitter, false, 288, reader ) );
+            }
+            else if( ( float )size / 276 == size / 276 )
+            {
+                for( var i = 0; i < size / 276; i++ ) Items.Add( new AvfxEmitterItem( IsParticle, Emitter, false, 276, reader ) );
+            }
+            else
+            {
+                Dalamud.Log( "size " + size.ToString() + " cannot be parsed" );
+            }
         }
 
         protected override IEnumerable<AvfxBase> GetChildren() {

--- a/VFXEditor/Formats/AvfxFormat/Model/AvfxModel.cs
+++ b/VFXEditor/Formats/AvfxFormat/Model/AvfxModel.cs
@@ -12,8 +12,10 @@ using VfxEditor.Utils;
 using VfxEditor.Utils.Gltf;
 using static VfxEditor.DirectX.ModelPreview;
 
-namespace VfxEditor.AvfxFormat {
-    public class AvfxModel : AvfxNode {
+namespace VfxEditor.AvfxFormat
+{
+    public class AvfxModel : AvfxNode
+    {
         public const string NAME = "Modl";
 
         public readonly AvfxVertexes Vertexes = new();
@@ -21,18 +23,22 @@ namespace VfxEditor.AvfxFormat {
         public readonly AvfxEmitVertexes EmitVertexes = new();
         public readonly AvfxEmitVertexNumbers EmitVertexNumbers = new();
 
-        public readonly List<UiEmitVertex> CombinedEmitVertexes = [];
+        public readonly List<UiEmitVertex> AllEmitVertexes = [];
+        public readonly List<UiVertexNumber> AllVertexNumbers = [];
 
         private readonly List<AvfxBase> Parsed;
 
         private readonly UiNodeGraphView NodeView;
         private readonly CommandTable<UiEmitVertex> VertexTable;
 
+        private readonly CommandTable<UiVertexNumber> VertexNumberTable;
+
         private int Mode = ( int )RenderMode.Color;
         private bool Refresh = false;
         private readonly UiModelUvView UvView;
 
-        public AvfxModel() : base( NAME, AvfxNodeGroupSet.ModelColor ) {
+        public AvfxModel() : base( NAME, AvfxNodeGroupSet.ModelColor )
+        {
             Parsed = [
                 EmitVertexNumbers,
                 EmitVertexes,
@@ -43,69 +49,91 @@ namespace VfxEditor.AvfxFormat {
             NodeView = new( this );
             UvView = new UiModelUvView();
 
-            VertexTable = new( "Emit", true, true, CombinedEmitVertexes, [
-                ( "Order", ImGuiTableColumnFlags.None, -1 ),
+            VertexNumberTable = new( "Number", true, true, AllVertexNumbers, [
+                ( "Number", ImGuiTableColumnFlags.None, -1 )
+            ],
+            () => new( new() ), ( UiVertexNumber item, bool add ) => RefreshModelPreview() );
+
+            VertexTable = new( "Emit", true, true, AllEmitVertexes, [
                 ( "Position", ImGuiTableColumnFlags.None, -1 ),
                 ( "Normal", ImGuiTableColumnFlags.None, -1 ),
                 ( "Color", ImGuiTableColumnFlags.None, - 1),
             ],
-            () => new( this, new(), new() ), ( UiEmitVertex item, bool add ) => RefreshModelPreview() );
+            () => new( this, new() ), ( UiEmitVertex item, bool add ) => RefreshModelPreview() );
+
         }
 
-        public override void ReadContents( BinaryReader reader, int size ) {
+        public override void ReadContents( BinaryReader reader, int size )
+        {
             ReadNested( reader, Parsed, size );
-            if( EmitVertexes.EmitVertexes.Count != EmitVertexNumbers.VertexNumbers.Count ) {
+            if( EmitVertexes.EmitVertexes.Count != EmitVertexNumbers.VertexNumbers.Count )
+            {
                 Dalamud.Error( $"Mismatched emit vertex counts {EmitVertexes.EmitVertexes.Count} {EmitVertexNumbers.VertexNumbers.Count}" );
             }
-            for( var i = 0; i < Math.Min( EmitVertexes.EmitVertexes.Count, EmitVertexNumbers.VertexNumbers.Count ); i++ ) {
-                CombinedEmitVertexes.Add( new UiEmitVertex( this, EmitVertexes.EmitVertexes[i], EmitVertexNumbers.VertexNumbers[i] ) );
+            for( var i = 0; i < EmitVertexes.EmitVertexes.Count; i++ )
+            {
+                AllEmitVertexes.Add( new UiEmitVertex( this, EmitVertexes.EmitVertexes[i] ) );
+            }
+            for( var i = 0; i < EmitVertexNumbers.VertexNumbers.Count; i++ )
+            {
+                AllVertexNumbers.Add( new UiVertexNumber( EmitVertexNumbers.VertexNumbers[i] ) );
             }
         }
 
-        public override void WriteContents( BinaryWriter writer ) {
-            EmitVertexes.EmitVertexes.Clear();
-            EmitVertexes.EmitVertexes.AddRange( CombinedEmitVertexes.Select( x => x.Vertex ) );
-
+        public override void WriteContents( BinaryWriter writer )
+        {
             EmitVertexNumbers.VertexNumbers.Clear();
-            EmitVertexNumbers.VertexNumbers.AddRange( CombinedEmitVertexes.Select( x => x.Number ) );
+            EmitVertexNumbers.VertexNumbers.AddRange( AllVertexNumbers.Select( x => x.Number ) );
 
-            if( EmitVertexNumbers.VertexNumbers.Count > 0 ) {
+            EmitVertexes.EmitVertexes.Clear();
+            EmitVertexes.EmitVertexes.AddRange( AllEmitVertexes.Select( x => x.Vertex ) );
+
+            if( EmitVertexNumbers.VertexNumbers.Count > 0 )
+            {
                 EmitVertexNumbers.SetAssigned( true );
                 EmitVertexNumbers.Write( writer );
             }
 
-            if( EmitVertexes.EmitVertexes.Count > 0 ) {
+            if( EmitVertexes.EmitVertexes.Count > 0 )
+            {
                 EmitVertexes.SetAssigned( true );
                 EmitVertexes.Write( writer );
             }
 
-            if( Vertexes.Vertexes.Count > 0 ) {
+            if( Vertexes.Vertexes.Count > 0 )
+            {
                 Vertexes.SetAssigned( true );
                 Vertexes.Write( writer );
             }
 
-            if( Indexes.Indexes.Count > 0 ) {
+            if( Indexes.Indexes.Count > 0 )
+            {
                 Indexes.SetAssigned( true );
                 Indexes.Write( writer );
             }
         }
 
-        protected override IEnumerable<AvfxBase> GetChildren() {
+        protected override IEnumerable<AvfxBase> GetChildren()
+        {
             foreach( var item in Parsed ) yield return item;
         }
 
-        public override void Draw() {
+        public override void Draw()
+        {
             using var _ = ImRaii.PushId( "Model" );
             NodeView.Draw();
             DrawRename();
 
             ImGui.TextDisabled( $"Vertices: {Vertexes.Vertexes.Count} Indexes: {Indexes.Indexes.Count}" );
 
-            using( var style = ImRaii.PushStyle( ImGuiStyleVar.ItemSpacing, ImGui.GetStyle().ItemInnerSpacing ) ) {
+            using( var style = ImRaii.PushStyle( ImGuiStyleVar.ItemSpacing, ImGui.GetStyle().ItemInnerSpacing ) )
+            {
                 if( ImGui.Button( "Export" ) ) ImGui.OpenPopup( "ExportPopup" );
 
-                using( var popup = ImRaii.Popup( "ExportPopup" ) ) {
-                    if( popup ) {
+                using( var popup = ImRaii.Popup( "ExportPopup" ) )
+                {
+                    if( popup )
+                    {
                         if( ImGui.Selectable( ".gltf" ) ) ExportDialog();
                         if( ImGui.Selectable( ".avfx" ) ) Plugin.AvfxManager.ShowExportDialog( this );
                     }
@@ -123,20 +151,29 @@ namespace VfxEditor.AvfxFormat {
             using var tabBar = ImRaii.TabBar( "ModelTabs" );
             if( !tabBar ) return;
 
-            using( var tab = ImRaii.TabItem( "3D View" ) ) {
+            using( var tab = ImRaii.TabItem( "3D View" ) )
+            {
                 if( tab ) DrawModel3D();
             }
 
-            using( var tab = ImRaii.TabItem( "UV View" ) ) {
+            using( var tab = ImRaii.TabItem( "UV View" ) )
+            {
                 if( tab ) UvView.Draw();
             }
 
-            using( var tab = ImRaii.TabItem( "Emitter Vertices" ) ) {
+            using( var tab = ImRaii.TabItem( "Vertex Order" ) )
+            {
+                if( tab ) DrawVertexnumbers();
+            }
+
+            using( var tab = ImRaii.TabItem( "Emitter Vertices" ) )
+            {
                 if( tab ) DrawEmitterVertices();
             }
         }
 
-        private void DrawEmitterVertices() {
+        private void DrawEmitterVertices()
+        {
             var size = Plugin.Configuration.EmitterVertexSplitOpen ?
                 new Vector2( ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y / 2f ) :
                 new Vector2( ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y - UiUtils.AngleUpDownSize );
@@ -145,34 +182,46 @@ namespace VfxEditor.AvfxFormat {
 
             if( UiUtils.DrawAngleUpDown( ref Plugin.Configuration.EmitterVertexSplitOpen ) ) Plugin.Configuration.Save();
 
-            if( Plugin.Configuration.EmitterVertexSplitOpen ) {
+            if( Plugin.Configuration.EmitterVertexSplitOpen )
+            {
                 CheckRefresh();
                 Plugin.DirectXManager.ModelPreview.DrawInline();
             }
         }
 
-        public void OnSelect() {
+
+        private void DrawVertexnumbers()
+        {
+            VertexNumberTable.Draw();
+        }
+
+        public void OnSelect()
+        {
             Plugin.DirectXManager.ModelPreview.LoadModel( this, RenderMode.Color );
             UvView.LoadModel( this );
         }
 
-        private void DrawModel3D() {
+        private void DrawModel3D()
+        {
             using var _ = ImRaii.PushId( "3DModel" );
 
-            if( ImGui.Checkbox( "Wireframe", ref Plugin.Configuration.ModelWireframe ) ) {
+            if( ImGui.Checkbox( "Wireframe", ref Plugin.Configuration.ModelWireframe ) )
+            {
                 Plugin.DirectXManager.ModelPreview.RefreshRasterizeState();
                 Plugin.DirectXManager.ModelPreview.Draw();
                 Plugin.Configuration.Save();
             }
 
             ImGui.SameLine();
-            if( ImGui.Checkbox( "Show Edges", ref Plugin.Configuration.ModelShowEdges ) ) {
+            if( ImGui.Checkbox( "Show Edges", ref Plugin.Configuration.ModelShowEdges ) )
+            {
                 Plugin.DirectXManager.ModelPreview.Draw();
                 Plugin.Configuration.Save();
             }
 
             ImGui.SameLine();
-            if( ImGui.Checkbox( "Show Emitter Vertices", ref Plugin.Configuration.ModelShowEmitters ) ) {
+            if( ImGui.Checkbox( "Show Emitter Vertices", ref Plugin.Configuration.ModelShowEmitters ) )
+            {
                 Plugin.DirectXManager.ModelPreview.Draw();
                 Plugin.Configuration.Save();
             }
@@ -198,7 +247,8 @@ namespace VfxEditor.AvfxFormat {
             Plugin.DirectXManager.ModelPreview.DrawInline();
         }
 
-        private void CheckRefresh() {
+        private void CheckRefresh()
+        {
             if( !Refresh ) return;
 
             Plugin.DirectXManager.ModelPreview.LoadModel( this, ( RenderMode )Mode );
@@ -206,21 +256,26 @@ namespace VfxEditor.AvfxFormat {
             Refresh = false;
         }
 
-        private void ImportDialog() {
+        private void ImportDialog()
+        {
             FileBrowserManager.OpenFileDialog( "Select a File", "GLTF{.gltf,.glb},.*", ( bool ok, string res ) => {
                 if( !ok ) return;
-                try {
-                    if( GltfModel.ImportModel( res, out var newVertexes, out var newIndexes ) ) {
+                try
+                {
+                    if( GltfModel.ImportModel( res, out var newVertexes, out var newIndexes ) )
+                    {
                         CommandManager.Add( new AvfxModelImportCommand( this, newIndexes, newVertexes ) );
                     }
                 }
-                catch( Exception e ) {
+                catch( Exception e )
+                {
                     Dalamud.Error( e, "Could not import data" );
                 }
             } );
         }
 
-        private void ExportDialog() {
+        private void ExportDialog()
+        {
             FileBrowserManager.SaveFileDialog( "Select a Save Location", ".gltf", "model", "gltf", ( bool ok, string res ) => {
                 if( !ok ) return;
                 GltfModel.ExportModel( this, res );

--- a/VFXEditor/Formats/AvfxFormat/Model/AvfxModel.cs
+++ b/VFXEditor/Formats/AvfxFormat/Model/AvfxModel.cs
@@ -12,10 +12,8 @@ using VfxEditor.Utils;
 using VfxEditor.Utils.Gltf;
 using static VfxEditor.DirectX.ModelPreview;
 
-namespace VfxEditor.AvfxFormat
-{
-    public class AvfxModel : AvfxNode
-    {
+namespace VfxEditor.AvfxFormat {
+    public class AvfxModel : AvfxNode {
         public const string NAME = "Modl";
 
         public readonly AvfxVertexes Vertexes = new();
@@ -37,8 +35,7 @@ namespace VfxEditor.AvfxFormat
         private bool Refresh = false;
         private readonly UiModelUvView UvView;
 
-        public AvfxModel() : base( NAME, AvfxNodeGroupSet.ModelColor )
-        {
+        public AvfxModel() : base( NAME, AvfxNodeGroupSet.ModelColor ) {
             Parsed = [
                 EmitVertexNumbers,
                 EmitVertexes,
@@ -63,8 +60,7 @@ namespace VfxEditor.AvfxFormat
 
         }
 
-        public override void ReadContents( BinaryReader reader, int size )
-        {
+        public override void ReadContents( BinaryReader reader, int size ) {
             ReadNested( reader, Parsed, size );
             if( EmitVertexes.EmitVertexes.Count != EmitVertexNumbers.VertexNumbers.Count )
             {
@@ -80,8 +76,7 @@ namespace VfxEditor.AvfxFormat
             }
         }
 
-        public override void WriteContents( BinaryWriter writer )
-        {
+        public override void WriteContents( BinaryWriter writer ) {
             EmitVertexNumbers.VertexNumbers.Clear();
             EmitVertexNumbers.VertexNumbers.AddRange( AllVertexNumbers.Select( x => x.Number ) );
 
@@ -113,27 +108,22 @@ namespace VfxEditor.AvfxFormat
             }
         }
 
-        protected override IEnumerable<AvfxBase> GetChildren()
-        {
+        protected override IEnumerable<AvfxBase> GetChildren() {
             foreach( var item in Parsed ) yield return item;
         }
 
-        public override void Draw()
-        {
+        public override void Draw() {
             using var _ = ImRaii.PushId( "Model" );
             NodeView.Draw();
             DrawRename();
 
             ImGui.TextDisabled( $"Vertices: {Vertexes.Vertexes.Count} Indexes: {Indexes.Indexes.Count}" );
 
-            using( var style = ImRaii.PushStyle( ImGuiStyleVar.ItemSpacing, ImGui.GetStyle().ItemInnerSpacing ) )
-            {
+            using( var style = ImRaii.PushStyle( ImGuiStyleVar.ItemSpacing, ImGui.GetStyle().ItemInnerSpacing ) ) {
                 if( ImGui.Button( "Export" ) ) ImGui.OpenPopup( "ExportPopup" );
 
-                using( var popup = ImRaii.Popup( "ExportPopup" ) )
-                {
-                    if( popup )
-                    {
+                using( var popup = ImRaii.Popup( "ExportPopup" ) ) {
+                    if( popup ) {
                         if( ImGui.Selectable( ".gltf" ) ) ExportDialog();
                         if( ImGui.Selectable( ".avfx" ) ) Plugin.AvfxManager.ShowExportDialog( this );
                     }
@@ -151,29 +141,24 @@ namespace VfxEditor.AvfxFormat
             using var tabBar = ImRaii.TabBar( "ModelTabs" );
             if( !tabBar ) return;
 
-            using( var tab = ImRaii.TabItem( "3D View" ) )
-            {
+            using( var tab = ImRaii.TabItem( "3D View" ) ) {
                 if( tab ) DrawModel3D();
             }
 
-            using( var tab = ImRaii.TabItem( "UV View" ) )
-            {
+            using( var tab = ImRaii.TabItem( "UV View" ) ) {
                 if( tab ) UvView.Draw();
             }
 
-            using( var tab = ImRaii.TabItem( "Vertex Order" ) )
-            {
+            using( var tab = ImRaii.TabItem( "Vertex Order" ) ) {
                 if( tab ) DrawVertexnumbers();
             }
 
-            using( var tab = ImRaii.TabItem( "Emitter Vertices" ) )
-            {
+            using( var tab = ImRaii.TabItem( "Emitter Vertices" ) ) {
                 if( tab ) DrawEmitterVertices();
             }
         }
 
-        private void DrawEmitterVertices()
-        {
+        private void DrawEmitterVertices() {
             var size = Plugin.Configuration.EmitterVertexSplitOpen ?
                 new Vector2( ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y / 2f ) :
                 new Vector2( ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y - UiUtils.AngleUpDownSize );
@@ -182,46 +167,39 @@ namespace VfxEditor.AvfxFormat
 
             if( UiUtils.DrawAngleUpDown( ref Plugin.Configuration.EmitterVertexSplitOpen ) ) Plugin.Configuration.Save();
 
-            if( Plugin.Configuration.EmitterVertexSplitOpen )
-            {
+            if( Plugin.Configuration.EmitterVertexSplitOpen ) {
                 CheckRefresh();
                 Plugin.DirectXManager.ModelPreview.DrawInline();
             }
         }
 
 
-        private void DrawVertexnumbers()
-        {
+        private void DrawVertexnumbers() {
             VertexNumberTable.Draw();
         }
 
-        public void OnSelect()
-        {
+        public void OnSelect() {
             Plugin.DirectXManager.ModelPreview.LoadModel( this, RenderMode.Color );
             UvView.LoadModel( this );
         }
 
-        private void DrawModel3D()
-        {
+        private void DrawModel3D() {
             using var _ = ImRaii.PushId( "3DModel" );
 
-            if( ImGui.Checkbox( "Wireframe", ref Plugin.Configuration.ModelWireframe ) )
-            {
+            if( ImGui.Checkbox( "Wireframe", ref Plugin.Configuration.ModelWireframe ) ) {
                 Plugin.DirectXManager.ModelPreview.RefreshRasterizeState();
                 Plugin.DirectXManager.ModelPreview.Draw();
                 Plugin.Configuration.Save();
             }
 
             ImGui.SameLine();
-            if( ImGui.Checkbox( "Show Edges", ref Plugin.Configuration.ModelShowEdges ) )
-            {
+            if( ImGui.Checkbox( "Show Edges", ref Plugin.Configuration.ModelShowEdges ) ) {
                 Plugin.DirectXManager.ModelPreview.Draw();
                 Plugin.Configuration.Save();
             }
 
             ImGui.SameLine();
-            if( ImGui.Checkbox( "Show Emitter Vertices", ref Plugin.Configuration.ModelShowEmitters ) )
-            {
+            if( ImGui.Checkbox( "Show Emitter Vertices", ref Plugin.Configuration.ModelShowEmitters ) ) {
                 Plugin.DirectXManager.ModelPreview.Draw();
                 Plugin.Configuration.Save();
             }
@@ -247,8 +225,7 @@ namespace VfxEditor.AvfxFormat
             Plugin.DirectXManager.ModelPreview.DrawInline();
         }
 
-        private void CheckRefresh()
-        {
+        private void CheckRefresh() {
             if( !Refresh ) return;
 
             Plugin.DirectXManager.ModelPreview.LoadModel( this, ( RenderMode )Mode );
@@ -256,26 +233,22 @@ namespace VfxEditor.AvfxFormat
             Refresh = false;
         }
 
-        private void ImportDialog()
-        {
+        private void ImportDialog() {
             FileBrowserManager.OpenFileDialog( "Select a File", "GLTF{.gltf,.glb},.*", ( bool ok, string res ) => {
                 if( !ok ) return;
                 try
                 {
-                    if( GltfModel.ImportModel( res, out var newVertexes, out var newIndexes ) )
-                    {
+                    if( GltfModel.ImportModel( res, out var newVertexes, out var newIndexes ) ) {
                         CommandManager.Add( new AvfxModelImportCommand( this, newIndexes, newVertexes ) );
                     }
                 }
-                catch( Exception e )
-                {
+                catch( Exception e ) {
                     Dalamud.Error( e, "Could not import data" );
                 }
             } );
         }
 
-        private void ExportDialog()
-        {
+        private void ExportDialog() {
             FileBrowserManager.SaveFileDialog( "Select a Save Location", ".gltf", "model", "gltf", ( bool ok, string res ) => {
                 if( !ok ) return;
                 GltfModel.ExportModel( this, res );

--- a/VFXEditor/Formats/AvfxFormat/Model/AvfxModel.cs
+++ b/VFXEditor/Formats/AvfxFormat/Model/AvfxModel.cs
@@ -28,7 +28,6 @@ namespace VfxEditor.AvfxFormat {
 
         private readonly UiNodeGraphView NodeView;
         private readonly CommandTable<UiEmitVertex> VertexTable;
-
         private readonly CommandTable<UiVertexNumber> VertexNumberTable;
 
         private int Mode = ( int )RenderMode.Color;
@@ -62,16 +61,13 @@ namespace VfxEditor.AvfxFormat {
 
         public override void ReadContents( BinaryReader reader, int size ) {
             ReadNested( reader, Parsed, size );
-            if( EmitVertexes.EmitVertexes.Count != EmitVertexNumbers.VertexNumbers.Count )
-            {
+            if( EmitVertexes.EmitVertexes.Count != EmitVertexNumbers.VertexNumbers.Count ) {
                 Dalamud.Error( $"Mismatched emit vertex counts {EmitVertexes.EmitVertexes.Count} {EmitVertexNumbers.VertexNumbers.Count}" );
             }
-            for( var i = 0; i < EmitVertexes.EmitVertexes.Count; i++ )
-            {
+            for( var i = 0; i < EmitVertexes.EmitVertexes.Count; i++ ) {
                 AllEmitVertexes.Add( new UiEmitVertex( this, EmitVertexes.EmitVertexes[i] ) );
             }
-            for( var i = 0; i < EmitVertexNumbers.VertexNumbers.Count; i++ )
-            {
+            for( var i = 0; i < EmitVertexNumbers.VertexNumbers.Count; i++ ) {
                 AllVertexNumbers.Add( new UiVertexNumber( EmitVertexNumbers.VertexNumbers[i] ) );
             }
         }
@@ -83,26 +79,22 @@ namespace VfxEditor.AvfxFormat {
             EmitVertexes.EmitVertexes.Clear();
             EmitVertexes.EmitVertexes.AddRange( AllEmitVertexes.Select( x => x.Vertex ) );
 
-            if( EmitVertexNumbers.VertexNumbers.Count > 0 )
-            {
+            if( EmitVertexNumbers.VertexNumbers.Count > 0 ) {
                 EmitVertexNumbers.SetAssigned( true );
                 EmitVertexNumbers.Write( writer );
             }
 
-            if( EmitVertexes.EmitVertexes.Count > 0 )
-            {
+            if( EmitVertexes.EmitVertexes.Count > 0 ) {
                 EmitVertexes.SetAssigned( true );
                 EmitVertexes.Write( writer );
             }
 
-            if( Vertexes.Vertexes.Count > 0 )
-            {
+            if( Vertexes.Vertexes.Count > 0 ) {
                 Vertexes.SetAssigned( true );
                 Vertexes.Write( writer );
             }
 
-            if( Indexes.Indexes.Count > 0 )
-            {
+            if( Indexes.Indexes.Count > 0 ) {
                 Indexes.SetAssigned( true );
                 Indexes.Write( writer );
             }
@@ -236,8 +228,7 @@ namespace VfxEditor.AvfxFormat {
         private void ImportDialog() {
             FileBrowserManager.OpenFileDialog( "Select a File", "GLTF{.gltf,.glb},.*", ( bool ok, string res ) => {
                 if( !ok ) return;
-                try
-                {
+                try {
                     if( GltfModel.ImportModel( res, out var newVertexes, out var newIndexes ) ) {
                         CommandManager.Add( new AvfxModelImportCommand( this, newIndexes, newVertexes ) );
                     }

--- a/VFXEditor/Formats/AvfxFormat/Model/Emit/UiEmitVertex.cs
+++ b/VFXEditor/Formats/AvfxFormat/Model/Emit/UiEmitVertex.cs
@@ -3,29 +3,25 @@ using System.Numerics;
 using VfxEditor.Data.Command;
 using VfxEditor.Ui.Interfaces;
 
-namespace VfxEditor.AvfxFormat {
-    public class UiEmitVertex : IUiItem {
+namespace VfxEditor.AvfxFormat
+{
+    public class UiEmitVertex : IUiItem
+    {
         public readonly AvfxEmitVertex Vertex;
-        public readonly AvfxVertexNumber Number;
-
         private readonly AvfxModel Model;
 
         public Vector3 Position => Vertex.Position.Value;
         public Vector3 Normal => Vertex.Normal.Value;
-        public int Order => Number.Order.Value;
 
-        public UiEmitVertex( AvfxModel model, AvfxEmitVertex vertex, AvfxVertexNumber number ) {
+        public UiEmitVertex( AvfxModel model, AvfxEmitVertex vertex )
+        {
             Model = model;
             Vertex = vertex;
-            Number = number;
         }
 
-        public void Draw() {
+        public void Draw()
+        {
             using var edited = new Edited();
-
-            ImGui.TableNextColumn();
-            ImGui.SetNextItemWidth( 50 );
-            Number.Order.Draw();
 
             ImGui.TableNextColumn();
             ImGui.SetNextItemWidth( 170 );

--- a/VFXEditor/Formats/AvfxFormat/Model/Emit/UiEmitVertex.cs
+++ b/VFXEditor/Formats/AvfxFormat/Model/Emit/UiEmitVertex.cs
@@ -3,24 +3,20 @@ using System.Numerics;
 using VfxEditor.Data.Command;
 using VfxEditor.Ui.Interfaces;
 
-namespace VfxEditor.AvfxFormat
-{
-    public class UiEmitVertex : IUiItem
-    {
+namespace VfxEditor.AvfxFormat {
+    public class UiEmitVertex : IUiItem {
         public readonly AvfxEmitVertex Vertex;
         private readonly AvfxModel Model;
 
         public Vector3 Position => Vertex.Position.Value;
         public Vector3 Normal => Vertex.Normal.Value;
 
-        public UiEmitVertex( AvfxModel model, AvfxEmitVertex vertex )
-        {
+        public UiEmitVertex( AvfxModel model, AvfxEmitVertex vertex ) {
             Model = model;
             Vertex = vertex;
         }
 
-        public void Draw()
-        {
+        public void Draw() {
             using var edited = new Edited();
 
             ImGui.TableNextColumn();

--- a/VFXEditor/Formats/AvfxFormat/Model/Emit/UiVertexNumber.cs
+++ b/VFXEditor/Formats/AvfxFormat/Model/Emit/UiVertexNumber.cs
@@ -1,0 +1,27 @@
+using ImGuiNET;
+using System.Numerics;
+using VfxEditor.Data.Command;
+using VfxEditor.Ui.Interfaces;
+
+namespace VfxEditor.AvfxFormat
+{
+    public class UiVertexNumber : IUiItem
+    {
+        public readonly AvfxVertexNumber Number;
+
+        public UiVertexNumber( AvfxVertexNumber number )
+        {
+            Number = number;
+        }
+
+        public void Draw()
+        {
+            using var edited = new Edited();
+
+            ImGui.TableNextColumn();
+            ImGui.SetNextItemWidth( 50 );
+            Number.Order.Draw();
+
+        }
+    }
+}

--- a/VFXEditor/Formats/AvfxFormat/Nodes/Select/AvfxNodeSelect.cs
+++ b/VFXEditor/Formats/AvfxFormat/Nodes/Select/AvfxNodeSelect.cs
@@ -49,10 +49,12 @@ namespace VfxEditor.AvfxFormat {
 
         public void LinkParentChild( AvfxNode node ) {
             if( node == null ) return;
-
-            Node.ChildNodes.Add( node );
-            node.Parents.Add( this );
-            OutdatedGraph( node );
+            if( !( Node == node ) )
+            {
+                Node.ChildNodes.Add( node );
+                node.Parents.Add( this );
+                OutdatedGraph( node );
+            }
         }
 
         private void OutdatedGraph( AvfxNode node ) {

--- a/VFXEditor/Formats/AvfxFormat/Particle/AvfxParticle.cs
+++ b/VFXEditor/Formats/AvfxFormat/Particle/AvfxParticle.cs
@@ -60,10 +60,10 @@ namespace VfxEditor.AvfxFormat {
         public readonly AvfxCurve3Axis Rotation = new( "Rotation", "Rot", CurveType.Angle, locked: true );
         public readonly AvfxCurve3Axis Position = new( "Position", "Pos", locked: true );
         public readonly AvfxCurve1Axis RotVelX = new( "Rotation Velocity X", "VRX" );
-        public readonly AvfxCurve1Axis RotVelY = new( "Rotation Velocity Y", "VRY" );
-        public readonly AvfxCurve1Axis RotVelZ = new( "Rotation Velocity Z", "VRZ" );
         public readonly AvfxCurve1Axis RotVelXRandom = new( "Rotation Velocity X Random", "VRXR" );
+        public readonly AvfxCurve1Axis RotVelY = new( "Rotation Velocity Y", "VRY" );
         public readonly AvfxCurve1Axis RotVelYRandom = new( "Rotation Velocity Y Random", "VRYR" );
+        public readonly AvfxCurve1Axis RotVelZ = new( "Rotation Velocity Z", "VRZ" );
         public readonly AvfxCurve1Axis RotVelZRandom = new( "Rotation Velocity Z Random", "VRZR" );
         public readonly AvfxCurveColor Color = new( "Color", locked: true );
 
@@ -156,10 +156,10 @@ namespace VfxEditor.AvfxFormat {
                 Rotation,
                 Position,
                 RotVelX,
-                RotVelY,
-                RotVelZ,
                 RotVelXRandom,
+                RotVelY,
                 RotVelYRandom,
+                RotVelZ,
                 RotVelZRandom,
                 Color
             ];
@@ -227,10 +227,10 @@ namespace VfxEditor.AvfxFormat {
                 Rotation,
                 Position,
                 RotVelX,
-                RotVelY,
-                RotVelZ,
                 RotVelXRandom,
+                RotVelY,
                 RotVelYRandom,
+                RotVelZ,
                 RotVelZRandom,
                 Color
             ] );

--- a/VFXEditor/Formats/EidFormat/EidFile.cs
+++ b/VFXEditor/Formats/EidFormat/EidFile.cs
@@ -37,10 +37,19 @@ namespace VfxEditor.EidFormat {
 
             if( verify ) Verified = FileUtils.Verify( reader, ToBytes() );
 
-            Dropdown = new( "Bind Point", BindPoints,
-                ( EidBindPoint item, int idx ) => $"Bind Point {item.GetName()}", () => new EidBindPointNew( this ) );
 
-            Skeleton = new( this, Path.IsPathRooted( sourcePath ) ? null : sourcePath );
+            if( NewData )
+            {
+                Dropdown = new( "Bind Point", BindPoints,
+                    ( EidBindPoint item, int idx ) => $"Bind Point {item.GetName()}", () => new EidBindPointNew( this ) );
+            }
+            else
+            {
+                Dropdown = new( "Bind Point", BindPoints,
+                    ( EidBindPoint item, int idx ) => $"Bind Point {item.GetName()}", () => new EidBindPointOld( this ) );
+
+            }
+                Skeleton = new( this, Path.IsPathRooted( sourcePath ) ? null : sourcePath );
         }
 
         public override void Write( BinaryWriter writer ) {

--- a/VFXEditor/Parsing/Float/ParsedFloat.cs
+++ b/VFXEditor/Parsing/Float/ParsedFloat.cs
@@ -1,8 +1,10 @@
 using ImGuiNET;
 using System.IO;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public class ParsedFloat : ParsedSimpleBase<float> {
+        public bool HighPrecision = true;
         public ParsedFloat( string name, float value ) : base( name, value ) { }
 
         public ParsedFloat( string name ) : base( name ) { }
@@ -17,7 +19,7 @@ namespace VfxEditor.Parsing {
 
         protected override void DrawBody() {
             var value = Value;
-            if( ImGui.InputFloat( Name, ref value ) ) {
+            if( ImGui.InputFloat( Name, ref value, 0.0f, 0.0f, HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f") ) {
                 Update( value );
             }
         }

--- a/VFXEditor/Parsing/Float/ParsedFloat2.cs
+++ b/VFXEditor/Parsing/Float/ParsedFloat2.cs
@@ -1,9 +1,11 @@
 using ImGuiNET;
 using System.IO;
 using System.Numerics;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public class ParsedFloat2 : ParsedSimpleBase<Vector2> {
+        public bool HighPrecision = true;
         public ParsedFloat2( string name, Vector2 value ) : base( name, value ) { }
 
         public ParsedFloat2( string name ) : base( name ) { }
@@ -22,7 +24,7 @@ namespace VfxEditor.Parsing {
 
         protected override void DrawBody() {
             var value = Value;
-            if( ImGui.InputFloat2( Name, ref value ) ) Update( value );
+            if( ImGui.InputFloat2( Name, ref value, HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) ) Update( value );
         }
     }
 }

--- a/VFXEditor/Parsing/Float/ParsedFloat3.cs
+++ b/VFXEditor/Parsing/Float/ParsedFloat3.cs
@@ -5,7 +5,7 @@ using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public class ParsedFloat3 : ParsedSimpleBase<Vector3> {
-        public bool HighPrecision = false;
+        public bool HighPrecision = true;
 
         public ParsedFloat3( string name, Vector3 value ) : base( name, value ) { }
 

--- a/VFXEditor/Parsing/Float/ParsedFloat4.cs
+++ b/VFXEditor/Parsing/Float/ParsedFloat4.cs
@@ -1,9 +1,11 @@
 using ImGuiNET;
 using System.IO;
 using System.Numerics;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public class ParsedFloat4 : ParsedSimpleBase<Vector4> {
+        public bool HighPrecision = true;
         public ParsedFloat4( string name, Vector4 value ) : base( name, value ) { }
 
         public ParsedFloat4( string name ) : base( name ) { }
@@ -26,7 +28,7 @@ namespace VfxEditor.Parsing {
 
         protected override void DrawBody() {
             var value = Value;
-            if( ImGui.InputFloat4( Name, ref value ) ) Update( value );
+            if( ImGui.InputFloat4( Name, ref value, HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) )  Update( value );
         }
     }
 }

--- a/VFXEditor/Parsing/UiComponents/UiParsedFloat2.cs
+++ b/VFXEditor/Parsing/UiComponents/UiParsedFloat2.cs
@@ -2,12 +2,14 @@ using ImGuiNET;
 using System.Numerics;
 using VfxEditor.Data.Copy;
 using VfxEditor.Ui.Interfaces;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public class UiParsedFloat2 : IUiItem {
         public readonly string Name;
         public readonly ParsedFloat P1;
         public readonly ParsedFloat P2;
+        public bool HighPrecision = true;
 
         private Vector2 Value => new( P1.Value, P2.Value );
 
@@ -28,7 +30,7 @@ namespace VfxEditor.Parsing {
             }
 
             var value = Value;
-            if( ImGui.InputFloat2( Name, ref value ) ) {
+            if( ImGui.InputFloat2( Name, ref value, HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) ) {
                 CommandManager.Add( new CompoundCommand( new[] {
                     new ParsedSimpleCommand<float>( P1, value.X ),
                     new ParsedSimpleCommand<float>( P2, value.Y )

--- a/VFXEditor/Parsing/UiComponents/UiParsedFloat3.cs
+++ b/VFXEditor/Parsing/UiComponents/UiParsedFloat3.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using VfxEditor.Data.Copy;
 using VfxEditor.Ui.Interfaces;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public class UiParsedFloat3 : IUiItem {
@@ -10,6 +11,7 @@ namespace VfxEditor.Parsing {
         public readonly ParsedFloat P1;
         public readonly ParsedFloat P2;
         public readonly ParsedFloat P3;
+        public bool HighPrecision = true;
 
         public Vector3 Value => new( P1.Value, P2.Value, P3.Value );
 
@@ -33,7 +35,7 @@ namespace VfxEditor.Parsing {
             }
 
             var value = Value;
-            if( ImGui.InputFloat3( Name, ref value ) ) {
+            if( ImGui.InputFloat3( Name, ref value, HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) ) {
                 var commands = new List<ICommand> {
                     new ParsedSimpleCommand<float>( P1, value.X ),
                     new ParsedSimpleCommand<float>( P2, value.Y ),

--- a/VFXEditor/Parsing/UiComponents/UiParsedFloat4.cs
+++ b/VFXEditor/Parsing/UiComponents/UiParsedFloat4.cs
@@ -2,6 +2,7 @@ using ImGuiNET;
 using System.Numerics;
 using VfxEditor.Data.Copy;
 using VfxEditor.Ui.Interfaces;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public class UiParsedFloat4 : IUiItem {
@@ -10,6 +11,7 @@ namespace VfxEditor.Parsing {
         public readonly ParsedFloat P2;
         public readonly ParsedFloat P3;
         public readonly ParsedFloat P4;
+        public bool HighPrecision = true;
 
         private Vector4 Value => new( P1.Value, P2.Value, P3.Value, P4.Value );
 
@@ -34,7 +36,7 @@ namespace VfxEditor.Parsing {
             }
 
             var value = Value;
-            if( ImGui.InputFloat4( Name, ref value ) ) {
+            if( ImGui.InputFloat4( Name, ref value, HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) ) {
                 CommandManager.Add( new CompoundCommand( new[] {
                      new ParsedSimpleCommand<float>( P1, value.X ),
                      new ParsedSimpleCommand<float>( P2, value.Y ),

--- a/VFXEditor/Utils/UiUtils.cs
+++ b/VFXEditor/Utils/UiUtils.cs
@@ -44,7 +44,7 @@ namespace VfxEditor.Utils {
 
         public static Vector4 PARSED_GREEN => StyleModel.GetFromCurrent().BuiltInColors.ParsedGreen.Value;
 
-        public static readonly string HIGH_PRECISION_FORMAT = "%.5f";
+        public static readonly string HIGH_PRECISION_FORMAT = "%.7f";
 
         public static string GetArticle( string input ) => "aeiouAEIOU".Contains( input[0] ) ? "an" : "a";
 


### PR DESCRIPTION
This does a bunch of things:
- Fixes the EID editor always adding newEIDtype even if file is of old type.
- Expands float precision to the full 7 significant digits. This is needed for some parameters like in simple animations that are much more sensitive. Plus it's better to just expose the full float if the file has more precision.
- Splits vertex numbers[renamed to vertex order] and vertex emitters. This allows all vertex emitters to be displayed and edited if there is a count mismatch, as well as reflects the actual behaviour of the game where they are independent properties.
- Added handling for emitter items smaller than 312 for all sizes we found in existing game files that were causing particles and emitters to be dropped. There may be others that crop up in the future. Note that this is only the import that is fixed, so it will still flag as a "parsing issue" since the internally produced VFXE file is produced with 312 size blocks. Also added a log output for if it hits a size it cannot handle.
- Added the path to the log output of the Loadgame exception.
- Suppressed Nodecreation for emitters that call themselves. This was causing a crashtodesktop when loading  some cutscene vfxs that had emitters not assigned to timelines that called themselves.
- Reorganized some of the particle parameters to match native files and prevent false positive parsing errors.

With all of these just note that I am not a coding genius so there may very well be better ways to handle all of these. :D
