### PR TITLE
Limit models to 8 and texn to 256

### DIFF
--- a/VFXEditor/Formats/AvfxFormat/Nodes/SelectList/AvfxNodeSelectList.cs
+++ b/VFXEditor/Formats/AvfxFormat/Nodes/SelectList/AvfxNodeSelectList.cs
@@ -14,11 +14,13 @@ namespace VfxEditor.AvfxFormat {
         public readonly string Name;
 
         private bool Enabled = true;
+        private int Limit;
 
-        public AvfxNodeSelectList( AvfxNode node, string name, NodeGroup<T> group, AvfxIntList literal ) : base( node ) {
+        public AvfxNodeSelectList( AvfxNode node, string name, NodeGroup<T> group, AvfxIntList literal, int limit = 4 ) : base( node ) {
             Name = name;
             Group = group;
             Literal = literal;
+            Limit = limit;
             if( Group.ImportInProgress ) group.OnImportFinish += ImportFinished;
             else {
                 LinkOnIndexChange();
@@ -189,7 +191,7 @@ namespace VfxEditor.AvfxFormat {
 
             if( Group.Items.Count == 0 ) ImGui.TextColored( UiUtils.RED_COLOR, "WARNING: Add a selectable item first!" );
 
-            if( Selected.Count < 4 ) {
+            if( Selected.Count < Limit ) {
                 if( ImGui.SmallButton( $"+ {Name}" ) ) CommandManager.Add( new AvfxNodeSelectListAddCommand<T>( this ) );
                 Literal.DrawUnassignPopup( Name );
             }

--- a/VFXEditor/Formats/AvfxFormat/Particle/Data/AvfxParticleDataModel.cs
+++ b/VFXEditor/Formats/AvfxFormat/Particle/Data/AvfxParticleDataModel.cs
@@ -42,7 +42,7 @@ namespace VfxEditor.AvfxFormat {
                 ColorEnd
             ];
 
-            ParameterTab.Add( ModelSelect = new AvfxNodeSelectList<AvfxModel>( particle, "Model", particle.NodeGroups.Models, ModelIdx ) );
+            ParameterTab.Add( ModelSelect = new AvfxNodeSelectList<AvfxModel>( particle, "Model", particle.NodeGroups.Models, ModelIdx, 8 ) );
             ParameterTab.Add( ModelNumberRandomValue );
             ParameterTab.Add( ModelNumberRandomType );
             ParameterTab.Add( ModelNumberRandomInterval );

--- a/VFXEditor/Formats/AvfxFormat/Particle/Texture/AvfxParticleTextureColor1.cs
+++ b/VFXEditor/Formats/AvfxFormat/Particle/Texture/AvfxParticleTextureColor1.cs
@@ -81,7 +81,7 @@ namespace VfxEditor.AvfxFormat {
         public override string GetDefaultText() => "Texture Color 1";
 
         public override List<AvfxNodeSelect> GetNodeSelects() => [
-            new AvfxNodeSelectList<AvfxTexture>( Particle, "Mask Texture", Particle.NodeGroups.Textures, MaskTextureIdx )
+            new AvfxNodeSelectList<AvfxTexture>( Particle, "Mask Texture", Particle.NodeGroups.Textures, MaskTextureIdx, 256 )
         ];
     }
 }


### PR DESCRIPTION
Increase the limit of nodes to 8 for models and 256 for textures instead of 4
From what I've tested, more than 8 models won't render anymore
I've only tested up to 64 for textures but it may be safe to assume we can go to 256 or even more?? 64 is already an excessive amount and I think the current code doesn't support further than 256 in any case