### PR TITLE
More small fixes.

### DIFF
--- a/VFXEditor/Formats/ScdFormat/Music/Marker/ScdAudioMarker.cs
+++ b/VFXEditor/Formats/ScdFormat/Music/Marker/ScdAudioMarker.cs
@@ -8,12 +8,14 @@ using VfxEditor.Parsing.String;
 using VfxEditor.ScdFormat;
 using VfxEditor.Ui.Components;
 using VfxEditor.Utils;
+using Serilog;
+using Dalamud.Plugin.Services;
 
 namespace VfxEditor.Formats.ScdFormat.Music.Marker {
     public class ScdAudioMarker {
         private ScdAudioEntry Entry;
 
-        public readonly ParsedPaddedString Id = new( "Id", 4, 0x00 );
+        public readonly ParsedPaddedString Id = new( "Id", 5, 0x00 );
         public readonly ParsedFloat LoopStart = new( "Loop Start" );
         public readonly ParsedFloat LoopEnd = new( "Loop End" );
 
@@ -36,8 +38,9 @@ namespace VfxEditor.Formats.ScdFormat.Music.Marker {
         public void Read( BinaryReader reader ) {
             Id.Value = FileUtils.ReadString( reader, 4 );
             reader.ReadUInt32();
-            LoopStart.Value = ( float )reader.ReadInt32() / Entry.SampleRate;
-            LoopEnd.Value = ( float )reader.ReadInt32() / Entry.SampleRate;
+            LoopStart.Value = reader.ReadSingle() / ( float )Entry.SampleRate;
+            Dalamud.Log("Input Loopstart:" + LoopStart.Value.ToString());
+            LoopEnd.Value = reader.ReadSingle() / ( float )Entry.SampleRate;
             var numMarkers = reader.ReadInt32();
 
             for( var i = 0; i < numMarkers; i++ ) {
@@ -53,8 +56,9 @@ namespace VfxEditor.Formats.ScdFormat.Music.Marker {
         public void Write( BinaryWriter writer ) {
             FileUtils.WriteString( writer, Id.Value );
             writer.Write( GetSize() );
-            writer.Write( ( int )( LoopStart.Value * Entry.SampleRate ) );
-            writer.Write( ( int )( LoopEnd.Value * Entry.SampleRate ) );
+            writer.Write( LoopStart.Value * ( float )Entry.SampleRate );
+            Dalamud.Log( "Output Loopstart:" + (( LoopStart.Value * Entry.SampleRate )).ToString() );
+            writer.Write( LoopEnd.Value * ( float )Entry.SampleRate );
             writer.Write( Markers.Count );
             foreach( var marker in Markers ) writer.Write( ( int )Math.Round( marker.Value * Entry.SampleRate, MidpointRounding.AwayFromZero ) );
 

--- a/VFXEditor/Formats/ScdFormat/Music/Marker/ScdAudioMarker.cs
+++ b/VFXEditor/Formats/ScdFormat/Music/Marker/ScdAudioMarker.cs
@@ -8,8 +8,6 @@ using VfxEditor.Parsing.String;
 using VfxEditor.ScdFormat;
 using VfxEditor.Ui.Components;
 using VfxEditor.Utils;
-using Serilog;
-using Dalamud.Plugin.Services;
 
 namespace VfxEditor.Formats.ScdFormat.Music.Marker {
     public class ScdAudioMarker {
@@ -38,9 +36,8 @@ namespace VfxEditor.Formats.ScdFormat.Music.Marker {
         public void Read( BinaryReader reader ) {
             Id.Value = FileUtils.ReadString( reader, 4 );
             reader.ReadUInt32();
-            LoopStart.Value = reader.ReadSingle() / ( float )Entry.SampleRate;
-            Dalamud.Log("Input Loopstart:" + LoopStart.Value.ToString());
-            LoopEnd.Value = reader.ReadSingle() / ( float )Entry.SampleRate;
+            LoopStart.Value = ( float )reader.ReadInt32() / Entry.SampleRate;
+            LoopEnd.Value = ( float )reader.ReadInt32() / Entry.SampleRate;
             var numMarkers = reader.ReadInt32();
 
             for( var i = 0; i < numMarkers; i++ ) {
@@ -56,9 +53,8 @@ namespace VfxEditor.Formats.ScdFormat.Music.Marker {
         public void Write( BinaryWriter writer ) {
             FileUtils.WriteString( writer, Id.Value );
             writer.Write( GetSize() );
-            writer.Write( LoopStart.Value * ( float )Entry.SampleRate );
-            Dalamud.Log( "Output Loopstart:" + (( LoopStart.Value * Entry.SampleRate )).ToString() );
-            writer.Write( LoopEnd.Value * ( float )Entry.SampleRate );
+            writer.Write( ( int )( LoopStart.Value * Entry.SampleRate ) );
+            writer.Write( ( int )( LoopEnd.Value * Entry.SampleRate ) );
             writer.Write( Markers.Count );
             foreach( var marker in Markers ) writer.Write( ( int )Math.Round( marker.Value * Entry.SampleRate, MidpointRounding.AwayFromZero ) );
 

--- a/VFXEditor/Formats/ScdFormat/Music/Marker/ScdAudioMarker.cs
+++ b/VFXEditor/Formats/ScdFormat/Music/Marker/ScdAudioMarker.cs
@@ -53,8 +53,8 @@ namespace VfxEditor.Formats.ScdFormat.Music.Marker {
         public void Write( BinaryWriter writer ) {
             FileUtils.WriteString( writer, Id.Value );
             writer.Write( GetSize() );
-            writer.Write( ( int )( LoopStart.Value * Entry.SampleRate ) );
-            writer.Write( ( int )( LoopEnd.Value * Entry.SampleRate ) );
+            writer.Write( ( int )Math.Round( LoopStart.Value * Entry.SampleRate, MidpointRounding.AwayFromZero ) );
+            writer.Write( ( int )Math.Round( LoopEnd.Value * Entry.SampleRate, MidpointRounding.AwayFromZero ) );
             writer.Write( Markers.Count );
             foreach( var marker in Markers ) writer.Write( ( int )Math.Round( marker.Value * Entry.SampleRate, MidpointRounding.AwayFromZero ) );
 

--- a/VFXEditor/Parsing/Double/ParsedDouble.cs
+++ b/VFXEditor/Parsing/Double/ParsedDouble.cs
@@ -1,8 +1,10 @@
 using Dalamud.Bindings.ImGui;
 using System.IO;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public class ParsedDouble : ParsedSimpleBase<double> {
+        public bool HighPrecision = true;
         public ParsedDouble( string name, double value ) : base( name, value ) { }
 
         public ParsedDouble( string name ) : base( name ) { }
@@ -17,7 +19,7 @@ namespace VfxEditor.Parsing {
 
         protected override void DrawBody() {
             var value = Value;
-            if( ImGui.InputDouble( Name, ref value ) ) {
+            if( ImGui.InputDouble( Name, ref value, 0.0f, 0.0f, format: HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) ) {
                 Update( value );
             }
         }

--- a/VFXEditor/Parsing/Double/ParsedDouble2.cs
+++ b/VFXEditor/Parsing/Double/ParsedDouble2.cs
@@ -1,6 +1,7 @@
 using Dalamud.Bindings.ImGui;
 using System.IO;
 using System.Numerics;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public struct Double2 {
@@ -16,6 +17,7 @@ namespace VfxEditor.Parsing {
     }
 
     public class ParsedDouble2 : ParsedSimpleBase<Double2> {
+        public bool HighPrecision = true;
         public ParsedDouble2( string name, Double2 value ) : base( name, value ) { }
 
         public ParsedDouble2( string name ) : base( name ) { }
@@ -34,7 +36,7 @@ namespace VfxEditor.Parsing {
 
         protected override void DrawBody() {
             var value = Value.Vec2;
-            if( ImGui.InputFloat2( Name, ref value ) ) Update( new( value ) );
+            if( ImGui.InputFloat2( Name, ref value, 0.0f, 0.0f, format: HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) ) Update( new( value ) );
         }
     }
 }

--- a/VFXEditor/Parsing/Double/ParsedDouble3.cs
+++ b/VFXEditor/Parsing/Double/ParsedDouble3.cs
@@ -1,6 +1,7 @@
 using Dalamud.Bindings.ImGui;
 using System.IO;
 using System.Numerics;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public struct Double3 {
@@ -18,6 +19,7 @@ namespace VfxEditor.Parsing {
     }
 
     public class ParsedDouble3 : ParsedSimpleBase<Double3> {
+        public bool HighPrecision = true;
         public ParsedDouble3( string name, Double3 value ) : base( name, value ) { }
 
         public ParsedDouble3( string name ) : base( name ) { }
@@ -38,7 +40,7 @@ namespace VfxEditor.Parsing {
 
         protected override void DrawBody() {
             var value = Value.Vec3;
-            if( ImGui.InputFloat3( Name, ref value ) ) Update( new( value ) );
+            if( ImGui.InputFloat3( Name, ref value, 0.0f, 0.0f, format: HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) ) Update( new( value ) );
         }
     }
 }

--- a/VFXEditor/Parsing/Double/ParsedDouble4.cs
+++ b/VFXEditor/Parsing/Double/ParsedDouble4.cs
@@ -1,6 +1,7 @@
 using Dalamud.Bindings.ImGui;
 using System.IO;
 using System.Numerics;
+using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
     public struct Double4 {
@@ -27,6 +28,7 @@ namespace VfxEditor.Parsing {
     }
 
     public class ParsedDouble4 : ParsedSimpleBase<Double4> {
+        public bool HighPrecision = true;
         public ParsedDouble4( string name, Double4 value ) : base( name, value ) { }
 
         public ParsedDouble4( string name ) : base( name ) { }
@@ -49,7 +51,7 @@ namespace VfxEditor.Parsing {
 
         protected override void DrawBody() {
             var value = Value.Vec4;
-            if( ImGui.InputFloat4( Name, ref value ) ) Update( new( value ) );
+            if( ImGui.InputFloat4( Name, ref value, 0.0f, 0.0f, format: HighPrecision ? UiUtils.HIGH_PRECISION_FORMAT : "%.3f" ) ) Update( new( value ) );
         }
     }
 }

--- a/VFXEditor/Parsing/Float/ParsedFloat2.cs
+++ b/VFXEditor/Parsing/Float/ParsedFloat2.cs
@@ -4,8 +4,7 @@ using System.Numerics;
 using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
-    public class ParsedFloat2 : ParsedSimpleBase<Vector2>
-    {
+    public class ParsedFloat2 : ParsedSimpleBase<Vector2> {
         public bool HighPrecision = true;
         public ParsedFloat2( string name, Vector2 value ) : base( name, value ) { }
 

--- a/VFXEditor/Parsing/Float/ParsedFloat4.cs
+++ b/VFXEditor/Parsing/Float/ParsedFloat4.cs
@@ -4,8 +4,7 @@ using System.Numerics;
 using VfxEditor.Utils;
 
 namespace VfxEditor.Parsing {
-    public class ParsedFloat4 : ParsedSimpleBase<Vector4>
-    {
+    public class ParsedFloat4 : ParsedSimpleBase<Vector4> {
         public bool HighPrecision = true;
         public ParsedFloat4( string name, Vector4 value ) : base( name, value ) { }
 

--- a/VFXEditor/Select/Tabs/Common/CommonTabShader.cs
+++ b/VFXEditor/Select/Tabs/Common/CommonTabShader.cs
@@ -25,7 +25,7 @@ namespace VfxEditor.Select.Tabs.Common {
         protected override void DrawSelected() {
             Dialog.DrawPaths( new Dictionary<string, string>() {
                 //{ "DX9", Selected.Path },
-                { "DX11", Selected.Path.Replace( "shader/", "shader/sm5/" ) }
+                { "DX11", Selected.Path }
             }, Selected.Name, SelectResultType.GameUi );
         }
     }


### PR DESCRIPTION
-Fixed Shader path selections.
-Fixed entry for marker id not allowing more than 4 characters and dropping existing 4th character.
-Added rounding to Marker loopstart and loopend times to solve parsing errors.
-Expanded precision if parseddouble entries to match floats.