### PR TITLE
additional SCD parsing

### DIFF
--- a/VFXEditor/Formats/ScdFormat/Sound/Data/SoundBusDucking.cs
+++ b/VFXEditor/Formats/ScdFormat/Sound/Data/SoundBusDucking.cs
@@ -6,35 +6,53 @@ namespace VfxEditor.ScdFormat.Sound.Data {
     public class SoundBusDucking {
         private byte Size = 0x10;
         public readonly ParsedByte Number = new( "Number" );
-        private readonly ParsedReserve Reserve1 = new( 2 );
+        private readonly ParsedByte Unknown1 = new( "Unknown 1" );
+        private readonly ParsedByte Unknown2 = new( "Unknown 2" );
         public readonly ParsedInt FadeTime = new( "Fade Time" );
         public readonly ParsedFloat Volume = new( "Volume" );
-        private uint Reserve2;
+        private readonly ParsedSByte Unknown3 = new( "Unknown 3" );
+        private readonly ParsedSByte Unknown4 = new( "Unknown 4" );
+        private readonly ParsedSByte Unknown5 = new( "Unknown 5" );
+        private readonly ParsedSByte Unknown6 = new( "Unknown 6" );
 
         public void Read( BinaryReader reader ) {
             Size = reader.ReadByte();
             Number.Read( reader );
-            Reserve1.Read( reader );
+            Unknown1.Read( reader );
+            Unknown2.Read( reader );
             FadeTime.Read( reader );
             Volume.Read( reader );
-            Reserve2 = reader.ReadUInt32();
+            Unknown3.Read( reader );
+            Unknown4.Read( reader );
+            Unknown5.Read( reader );
+            Unknown6.Read( reader );
         }
 
         public void Write( BinaryWriter writer ) {
             writer.Write( Size );
             Number.Write( writer );
-            Reserve1.Write( writer );
+            Unknown1.Write( writer );
+            Unknown2.Write( writer );
             FadeTime.Write( writer );
             Volume.Write( writer );
-            writer.Write( Reserve2 );
+            Unknown3.Write( writer );
+            Unknown4.Write( writer );
+            Unknown5.Write( writer );
+            Unknown6.Write( writer );
         }
 
         public void Draw() {
             using var _ = ImRaii.PushId( "BusDucking" );
 
             Number.Draw();
+            Unknown1.Draw();
+            Unknown2.Draw();
             FadeTime.Draw();
             Volume.Draw();
+            Unknown3.Draw();
+            Unknown4.Draw();
+            Unknown5.Draw();
+            Unknown6.Draw();
         }
     }
 }

--- a/VFXEditor/Formats/ScdFormat/Sound/Data/SoundExtra.cs
+++ b/VFXEditor/Formats/ScdFormat/Sound/Data/SoundExtra.cs
@@ -5,32 +5,40 @@ using VfxEditor.Parsing;
 namespace VfxEditor.ScdFormat.Sound.Data {
     public class SoundExtra {
         public readonly ParsedByte Version = new( "Version" );
-        private byte Reserved1;
+        private readonly ParsedByte Unknown1 = new( "Unknown 1" ); //Reserve 1
         private ushort Size = 0x10;
         public readonly ParsedInt PlayTimeLength = new( "Play Time Length" );
-        private readonly ParsedReserve Reserve2 = new( 2 * 4 );
+
+        //private readonly ParsedReserve Reserve2 = new( 2 * 4 );
+        private readonly ParsedInt Unknown2 = new( "Unknown 2" ); //DualSense vibration with 2; can also present as 10, 32, or 48, unrelated to DS
+        private readonly ParsedFloat Unknown3 = new( "Unknown 3" ); //0.0 or 999.0
 
         public void Read( BinaryReader reader ) {
             Version.Read( reader );
-            Reserved1 = reader.ReadByte();
+            Unknown1.Read( reader );
             Size = reader.ReadUInt16();
             PlayTimeLength.Read( reader );
-            Reserve2.Read( reader );
+            Unknown2.Read( reader );
+            Unknown3.Read( reader );
         }
 
         public void Write( BinaryWriter writer ) {
             Version.Write( writer );
-            writer.Write( Reserved1 );
+            Unknown1.Write( writer );
             writer.Write( Size );
             PlayTimeLength.Write( writer );
-            Reserve2.Write( writer );
+            Unknown2.Write( writer );
+            Unknown3.Write( writer );
         }
 
         public void Draw() {
             using var _ = ImRaii.PushId( "Extra" );
 
             Version.Draw();
+            Unknown1.Draw();
             PlayTimeLength.Draw();
+            Unknown2.Draw();
+            Unknown3.Draw();
         }
     }
 }

--- a/VFXEditor/Formats/ScdFormat/Sound/ScdSoundEntry.cs
+++ b/VFXEditor/Formats/ScdFormat/Sound/ScdSoundEntry.cs
@@ -56,7 +56,7 @@ namespace VfxEditor.ScdFormat {
         public readonly ParsedFloat Volume = new( "Volume" );
         public readonly ParsedShort LocalNumber = new( "Local Number" ); // TODO: ushort
         public readonly ParsedByte UserId = new( "User Id" );
-        public readonly ParsedByte PlayHistory = new( "Play History" ); // TODO: sbyte
+        public readonly ParsedSByte PlayHistory = new( "Play History" );
 
         public readonly SoundRoutingInfo RoutingInfo = new(); // include sendInfos, soundEffectParam
         public SoundBusDucking BusDucking = new();


### PR DESCRIPTION
changed ParsedReserve where applicable to allow modification and reading of otherwise lost data

relevant example files:
`sound/zingle/zingle_lvup_each5.scd` for Bus Ducking data
`sound/vfx/etc/SE_Vfx_Etc_mgc_mkd20_c.scd` for Extra Desc data

_Unknown #_ in Bus Ducking could probably be better presented in the GUI, but for now it's serviceable

also, a very minor fix for `Play History` to make it signed. not that we know what it really does anyway