### PR TITLE
common path jankery

### DIFF
--- a/VFXEditor/Select/Tabs/Common/CommonTabPap.cs
+++ b/VFXEditor/Select/Tabs/Common/CommonTabPap.cs
@@ -11,7 +11,7 @@ namespace VfxEditor.Select.Tabs.Common {
             var idx = 0;
             foreach( var line in File.ReadLines( SelectDataUtils.CommonPapPath ).Where( x => !string.IsNullOrEmpty( x ) ) ) {
                 if( !( line.Contains( "bt_common/event/" ) || line.Contains( "bt_common/event_base/" ) ) ) {
-                    Items.Add( new CommonRow( idx++, line, line.Replace( "chara/human/", "" ).Replace( "/animation/", ", " ).Replace( "/bt_common/", " -  " ).Replace( ".pap", "" ), 0 ) );
+                    Items.Add( new CommonRow( idx++, line, line.Replace( "chara/human/", "" ).Replace( "/animation/", ", " ).Replace( "/bt_common/", " -  " ).Replace( "/bt_", " -  bt_" ).Replace( ".pap", "" ), 0 ) );
                 }
             }
         }

--- a/VFXEditor/Select/Tabs/Common/CommonTabVfx.cs
+++ b/VFXEditor/Select/Tabs/Common/CommonTabVfx.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using Lumina.Excel.Sheets;
 
 namespace VfxEditor.Select.Tabs.Common {
     public class CommonTabVfx : SelectTab<CommonRow> {
@@ -33,7 +32,7 @@ namespace VfxEditor.Select.Tabs.Common {
 
             var idx = 0;
             foreach( var line in File.ReadLines( SelectDataUtils.CommonVfxPath ).Where( x => !string.IsNullOrEmpty( x ) ) ) {
-                Items.Add( new CommonRow( idx++, line, line.Replace( "bgcommon/", "" ).Replace( "vfx/lockon/eff/", "" ).Replace( "vfx/omen/eff/", "" ).Replace( "vfx/channeling/eff/", "" ).Replace( "world/common/", "").Replace( "hou/common/", "" ).Replace( ".avfx", "" ), 0 ) );
+                Items.Add( new CommonRow( idx++, line, line.Replace( "bgcommon/", "" ).Replace( "vfx/lockon/eff/", "" ).Replace( "vfx/monster/c0", "c0").Replace( "vfx/monster/c1", "c1").Replace( "vfx/omen/eff/", "" ).Replace( "vfx/channeling/eff/", "" ).Replace( "world/common/", "").Replace( "hou/common/", "" ).Replace( ".avfx", "" ), 0 ) );
             }
         }
 

--- a/scripts/reslog_common_files.py
+++ b/scripts/reslog_common_files.py
@@ -5,8 +5,9 @@ racial_pattern = re.compile("^chara/human/c(.*).(mdl|mtrl)")
 uld_pattern = re.compile("^ui/uld/(.*).uld$")
 shpk_pattern = re.compile("^shader/sm5/shpk/(.*).shpk$") # only sm5 exists in current builds. originally excluded
 shcd_pattern = re.compile("^shader/sm5/(posteffect|shcd)/(.*).shcd$")
-vfx_pattern = re.compile("^(vfx/channeling|vfx/lockon|vfx/omen|bgcommon|vfx/live)(.*).avfx$")
+vfx_pattern = re.compile("^(vfx/channeling|vfx/lockon|vfx/monster/c0|vfx/monster/c1|vfx/omen|bgcommon|vfx/live)(.*).avfx$")
 pap_pattern = re.compile("^chara/human/c(.*)/animation/a(.*)/bt_common/(event|event_base|gs|human_sp|idle_sp|music|normal|pc_contentsaction)/(.*).pap$")
+pap_pattern_craftgather = re.compile("^chara/human/c(.*)/animation/a(.*)/bt_(alc|arm|blk|wod|cok|gld|lth|sew|fel|fsh|min)_emp/(craft|diving_gather|event|fishing|fishing_chair|gather|harpoon|resident)/(.*).pap$")
 
 tmb_pattern = re.compile("chara/action/(.*).tmb")
 tmb_exceptionpattern = re.compile("chara/action/(ability|emote|emote_ajust|emote_sp|eureka|facial|human_sp|magic|mon_sp|mount_sp|rol_common|weapon|ws)/(.*).tmb") # checking against paths existing in other tabs. still has a few repeats
@@ -55,7 +56,7 @@ with open("CurrentPathList") as f:
             vfx.sort()
             continue
 
-        if pap_pattern.match(path):
+        if pap_pattern.match(path) or pap_pattern_craftgather.match(path):
             pap.append(path)
             pap.sort()
             continue


### PR DESCRIPTION
super-jank solution to add missing craft/gather PAPs (those in _Action_ only list _action.pap_) and human-NPC-based VFX. I'm not sure if the latter is possible to properly attribute anywhere, since bNPC doesn't provide a clean method to separate files for shared codes