### PR TITLE
Bugfixes for PAP Importer and PHYB Editor

### DIFF
--- a/VFXEditor/Formats/PhybFormat/Collision/Capsule/PhybCapsule.cs
+++ b/VFXEditor/Formats/PhybFormat/Collision/Capsule/PhybCapsule.cs
@@ -39,7 +39,9 @@ namespace VfxEditor.PhybFormat.Collision.Capsule {
             var startPos = Vector3Helper.TransformCoordinate( startOffset, startBone.BindPose );
             var endPos = Vector3Helper.TransformCoordinate( endOffset, endBone.BindPose );
 
-            meshes.Collision.AddCylinder( startPos, endPos, Radius.Value * 2f, 10 );
+            if( ( startPos - endPos ).Length() > 0.0001f ) {
+                meshes.Collision.AddCylinder( startPos, endPos, Radius.Value * 2f, 10 );
+            }
             meshes.Collision.AddSphere( startPos, Radius.Value, 10, 10 );
             meshes.Collision.AddSphere( endPos, Radius.Value, 10, 10 );
         }

--- a/VFXEditor/Formats/PhybFormat/Collision/NormalPlane/PhybNormalPlane.cs
+++ b/VFXEditor/Formats/PhybFormat/Collision/NormalPlane/PhybNormalPlane.cs
@@ -32,13 +32,16 @@ namespace VfxEditor.PhybFormat.Collision.NormalPlane {
             var offset = new Vector3( BoneOffset.Value.X, BoneOffset.Value.Y, BoneOffset.Value.Z );
             var pos = Vector3Helper.TransformCoordinate( offset, bone.BindPose );
 
-            var normal = Vector3.Normalize(new Vector3( Normal.Value.X, Normal.Value.Y, Normal.Value.Z ));
+            var normalVec = new Vector3( Normal.Value.X, Normal.Value.Y, Normal.Value.Z );
+            if( normalVec.Length() < 0.0001f ) return; // degenerate normal, cannot draw
+            var normal = Vector3.Normalize( normalVec );
             var tangent = Vector3.Cross( normal, Vector3.UnitY );
-            if( tangent.Length() == 0 ) {
+            if( tangent.Length() < 0.0001f ) {
                 tangent = Vector3.Cross( normal, Vector3.UnitX );
+                if( tangent.Length() < 0.0001f ) return;
             }
 
-            meshes.Collision.AddBox( pos, normal, Vector3.Normalize(tangent), 0.5f, 0.5f, Thickness.Value );
+            meshes.Collision.AddBox( pos, normal, Vector3.Normalize( tangent ), 0.5f, 0.5f, Thickness.Value );
         }
     }
 }

--- a/VFXEditor/Formats/PhybFormat/Simulator/PhybSimulator.cs
+++ b/VFXEditor/Formats/PhybFormat/Simulator/PhybSimulator.cs
@@ -221,6 +221,8 @@ namespace VfxEditor.PhybFormat.Simulator {
             MatrixHelper.DecomposeUniformScale( bone1.BindPose, out var _, out var _, out var pos1 );
             MatrixHelper.DecomposeUniformScale( bone2.BindPose, out var _, out var _, out var pos2 );
 
+            if( ( pos1 - pos2 ).Length() < 0.0001f ) return; // degenerate, cannot draw
+
             builder.AddCylinder( pos1, pos2, radius * 2f, 10 );
         }
 
@@ -238,7 +240,10 @@ namespace VfxEditor.PhybFormat.Simulator {
 
             var axisOffset = new Vector3( node.ConeAxisOffset.Value.Y, node.ConeAxisOffset.Value.X, -node.ConeAxisOffset.Value.Z );
             var axisPos = Vector4Helper.Transform( axisOffset.AsVector4(), ref nodeBone.BindPose ).ToVector3();
-            var norm = Vector3.Normalize( axisPos - nodeStart );
+            var axisDiff = axisPos - nodeStart;
+            if( axisDiff.Length() < 0.0001f ) return; // degenerate cone axis, cannot draw
+
+            var norm = Vector3.Normalize( axisDiff );
 
             // var boneDiff = bonePos - nodeStart;
             // var closest = norm * Vector3.Dot( boneDiff, norm );
@@ -250,6 +255,7 @@ namespace VfxEditor.PhybFormat.Simulator {
             var angle = node.ConeMaxAngle.Value;
             // tan(angle) = radius / distance
             var radius = Math.Tan( angle ) * distance;
+            if( !float.IsFinite( ( float )radius ) ) return; // NaN/infinity radius, cannot draw
 
             builder.AddCone( coneStart, coneEnd, ( float )radius , false, 10 );
         }

--- a/VFXEditor/Formats/PhybFormat/Skeleton/PhybSkeletonView.cs
+++ b/VFXEditor/Formats/PhybFormat/Skeleton/PhybSkeletonView.cs
@@ -1,6 +1,7 @@
 using HelixToolkit.Geometry;
 using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Core;
+using System;
 using System.Linq;
 using VfxEditor.Interop.Havok.Ui;
 
@@ -20,20 +21,26 @@ namespace VfxEditor.PhybFormat.Skeleton {
             File.PhysicsUpdated = false;
             if( Bones?.BoneList.Count == 0 ) return;
 
-            MeshBuilders meshes = new() {
-                Collision = new MeshBuilder( true, false ),
-                Simulation = new MeshBuilder( true, false ),
-                Spring = new MeshBuilder( true, false )
-            };
+            try {
+                MeshBuilders meshes = new() {
+                    Collision = new MeshBuilder( true, false ),
+                    Simulation = new MeshBuilder( true, false ),
+                    Spring = new MeshBuilder( true, false )
+                };
 
-            File.AddPhysicsObjects( meshes, Bones.BoneMatrixes );
-            Plugin.DirectXManager.BoneNameRenderer.SetWireFrame(
-                RenderId,
-                Instance,
-                meshes.Collision.ToMeshGeometry3D(),
-                meshes.Simulation.ToMeshGeometry3D(),
-                meshes.Spring.ToMeshGeometry3D()
-            );
+                File.AddPhysicsObjects( meshes, Bones.BoneMatrixes );
+                Plugin.DirectXManager.BoneNameRenderer.SetWireFrame(
+                    RenderId,
+                    Instance,
+                    meshes.Collision.ToMeshGeometry3D(),
+                    meshes.Simulation.ToMeshGeometry3D(),
+                    meshes.Spring.ToMeshGeometry3D()
+                );
+            }
+            catch( Exception e ) {
+                Dalamud.Error( e, "Could not update physics render data" );
+                return;
+            }
 
             var boneList = Bones.BoneList.Select( x => x.Name ).ToList();
             if( File.Extended != null ) {

--- a/VFXEditor/Utils/Gltf/GltfAnimation.cs
+++ b/VFXEditor/Utils/Gltf/GltfAnimation.cs
@@ -77,8 +77,9 @@ namespace VfxEditor.Utils.Gltf {
                 }
 
                 var animation = model.UseAnimation( animationName );
-                for( var time = 0f; time <= motion.Duration; time += 1 / 30f ) {
-                    ExportKeys( nameToKeys, names, motion, time );
+                var totalFrames = Math.Max( 1, ( int )MathF.Round( motion.Duration * 30f ) + 1 );
+                for( var frame = 0; frame < totalFrames; frame++ ) {
+                    ExportKeys( nameToKeys, names, motion, frame * ( 1 / 30f ) );
                 }
 
                 var unanimated = skipUnanimated ? motion.GetUnanimatedBones() : null;
@@ -203,7 +204,7 @@ namespace VfxEditor.Utils.Gltf {
                 if( scl != null ) sclSamplers[name] = scl;
             }
 
-            var numberOfFrames = ( int )Math.Ceiling( animation.Duration * 30f ) + 1;
+            var numberOfFrames = ( int )MathF.Round( animation.Duration * 30f ) + 1;
             for( var frame = 0; frame < numberOfFrames; frame++ ) {
                 var time = frame * ( 1 / 30f );
 


### PR DESCRIPTION
PAP / GLTF importer was occasionally dropping frames at the end of the animation, leading to hitches in what should have been clean looping animations. 

PHYB editor UI would reliably crash when loading configurations containing unsupported values.